### PR TITLE
feat: PR-3 add Discord API layer with rate limiting and pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,8 @@ opensrc/
 # Presets
 .discord-search-presets.json
 
+# Local config
+*.local.json
+
 # Traycer
 .traycer/

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -1,0 +1,257 @@
+import { Result } from "better-result";
+import type { z } from "zod";
+import { IndexNotReadyResponseSchema } from "@/discord/schemas.ts";
+import {
+  DiscordApiError,
+  IndexNotReadyError,
+  RateLimitExhaustedError,
+  ValidationError,
+} from "@/errors.ts";
+
+const DISCORD_API_BASE = "https://discord.com/api/v10";
+
+type RateLimitState = {
+  lastRequestTime: number;
+  remaining: number;
+  resetAfterMs: number;
+};
+
+const rateLimitState: RateLimitState = {
+  remaining: 1,
+  resetAfterMs: 0,
+  lastRequestTime: 0,
+};
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const updateRateLimitState = (headers: Headers): void => {
+  const remaining = headers.get("X-RateLimit-Remaining");
+  const resetAfter = headers.get("X-RateLimit-Reset-After");
+
+  if (remaining !== null) {
+    rateLimitState.remaining = Number.parseInt(remaining, 10);
+  }
+  if (resetAfter !== null) {
+    rateLimitState.resetAfterMs = Number.parseFloat(resetAfter) * 1000;
+  }
+  rateLimitState.lastRequestTime = Date.now();
+};
+
+const waitForRateLimit = async (): Promise<void> => {
+  if (rateLimitState.remaining > 0) {
+    return;
+  }
+
+  const elapsed = Date.now() - rateLimitState.lastRequestTime;
+  const waitTime = rateLimitState.resetAfterMs - elapsed;
+
+  if (waitTime > 0) {
+    await sleep(waitTime);
+  }
+};
+
+const makeHeaders = (token: string) => ({
+  Authorization: `Bot ${token}`,
+  "Content-Type": "application/json",
+});
+
+const fetchWithAuth = async (
+  url: string,
+  token: string
+): Promise<Result<Response, DiscordApiError>> => {
+  return await Result.tryPromise({
+    try: () => fetch(url, { headers: makeHeaders(token) }),
+    catch: (cause) =>
+      new DiscordApiError({
+        message: `Network error: ${cause instanceof Error ? cause.message : String(cause)}`,
+        status: 0,
+        body: null,
+      }),
+  });
+};
+
+type DiscordFetchError =
+  | DiscordApiError
+  | RateLimitExhaustedError
+  | IndexNotReadyError
+  | ValidationError;
+
+const handle429 = async (
+  response: Response,
+  attempt: number,
+  maxRetries: number
+): Promise<Result<"retry", DiscordApiError | RateLimitExhaustedError>> => {
+  const bodyResult = await Result.tryPromise({
+    try: () => response.json() as Promise<{ retry_after: number }>,
+    catch: () =>
+      new DiscordApiError({
+        message: "Failed to parse 429 response body",
+        status: 429,
+        body: null,
+      }),
+  });
+
+  if (bodyResult.isErr()) {
+    return bodyResult;
+  }
+
+  const retryAfter = bodyResult.value.retry_after;
+
+  if (attempt >= maxRetries) {
+    return Result.err(
+      new RateLimitExhaustedError({
+        message: `Rate limited after ${maxRetries} retries`,
+        retryAfter,
+      })
+    );
+  }
+
+  await sleep(retryAfter * 1000);
+  return Result.ok("retry" as const);
+};
+
+const handle202 = async <T>(
+  response: Response,
+  url: string,
+  token: string,
+  schema: z.ZodType<T>,
+  maxRetries: number
+): Promise<Result<T, DiscordFetchError>> => {
+  const bodyResult = await Result.tryPromise({
+    try: () => response.json() as Promise<unknown>,
+    catch: () =>
+      new DiscordApiError({
+        message: "Failed to parse 202 response body",
+        status: 202,
+        body: null,
+      }),
+  });
+
+  if (bodyResult.isErr()) {
+    return bodyResult;
+  }
+
+  const parsed = IndexNotReadyResponseSchema.safeParse(bodyResult.value);
+  const retryAfter = parsed.success ? parsed.data.retry_after || 2 : 2;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    await sleep(retryAfter * 1000);
+    await waitForRateLimit();
+
+    const retryResult = await fetchWithAuth(url, token);
+    if (retryResult.isErr()) {
+      return retryResult;
+    }
+
+    const retryResponse = retryResult.value;
+    updateRateLimitState(retryResponse.headers);
+
+    if (retryResponse.status !== 202) {
+      return await parseResponse(retryResponse, schema);
+    }
+  }
+
+  return Result.err(
+    new IndexNotReadyError({
+      message: `Index still not available after ${maxRetries} retries`,
+      retryAfter,
+    })
+  );
+};
+
+const handleErrorResponse = async (
+  response: Response
+): Promise<Result<never, DiscordApiError>> => {
+  const bodyResult = await Result.tryPromise({
+    try: () => response.json() as Promise<unknown>,
+    catch: () => null as unknown,
+  });
+
+  return Result.err(
+    new DiscordApiError({
+      message: `Discord API error: ${response.status} ${response.statusText}`,
+      status: response.status,
+      body: bodyResult.isOk() ? bodyResult.value : null,
+    })
+  );
+};
+
+const parseResponse = async <T>(
+  response: Response,
+  schema: z.ZodType<T>
+): Promise<Result<T, DiscordApiError | ValidationError>> => {
+  const jsonResult = await Result.tryPromise({
+    try: () => response.json() as Promise<unknown>,
+    catch: (cause) =>
+      new DiscordApiError({
+        message: `Failed to parse response JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+        status: response.status,
+        body: null,
+      }),
+  });
+
+  if (jsonResult.isErr()) {
+    return jsonResult;
+  }
+
+  const parsed = schema.safeParse(jsonResult.value);
+
+  if (!parsed.success) {
+    return Result.err(
+      new ValidationError({
+        message: "Discord API response validation failed",
+        issues: parsed.error,
+      })
+    );
+  }
+
+  return Result.ok(parsed.data);
+};
+
+export const discordFetch = async <T>(
+  path: string,
+  schema: z.ZodType<T>,
+  token: string,
+  maxRetries429 = 3,
+  maxRetries202 = 5
+): Promise<Result<T, DiscordFetchError>> => {
+  const url = `${DISCORD_API_BASE}${path}`;
+
+  for (let attempt = 0; attempt <= maxRetries429; attempt++) {
+    await waitForRateLimit();
+
+    const fetchResult = await fetchWithAuth(url, token);
+    if (fetchResult.isErr()) {
+      return fetchResult;
+    }
+
+    const response = fetchResult.value;
+    updateRateLimitState(response.headers);
+
+    if (response.status === 429) {
+      const result = await handle429(response, attempt, maxRetries429);
+      if (result.isErr()) {
+        return result;
+      }
+      continue;
+    }
+
+    if (response.status === 202) {
+      return await handle202(response, url, token, schema, maxRetries202);
+    }
+
+    if (!response.ok) {
+      return await handleErrorResponse(response);
+    }
+
+    return await parseResponse(response, schema);
+  }
+
+  return Result.err(
+    new RateLimitExhaustedError({
+      message: "Rate limit retries exhausted",
+      retryAfter: 0,
+    })
+  );
+};

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -101,10 +101,12 @@ type DiscordFetchError =
   | IndexNotReadyError
   | ValidationError;
 
+const MAX_429_RETRIES = 5;
+
 const handle429 = async (
   response: Response,
-  attempt: number,
-  maxRetries: number
+  rateLimitAttempt: number,
+  max429Retries: number
 ): Promise<Result<"retry", DiscordApiError | RateLimitExhaustedError>> => {
   const bodyResult = await Result.tryPromise({
     try: () => response.json() as Promise<unknown>,
@@ -133,16 +135,17 @@ const handle429 = async (
 
   const retryAfter = parsed.data.retry_after;
 
-  if (attempt >= maxRetries) {
+  if (rateLimitAttempt >= max429Retries) {
     return Result.err(
       new RateLimitExhaustedError({
-        message: `Rate limited after ${maxRetries} retries`,
+        message: `Rate limited after ${max429Retries} retries`,
         retryAfter,
       })
     );
   }
 
-  const backoffMs = retryAfter * 1000 * 2 ** attempt + Math.random() * 1000;
+  const backoffMs =
+    retryAfter * 1000 * 2 ** rateLimitAttempt + Math.random() * 1000;
   await sleep(backoffMs);
   return Result.ok("retry" as const);
 };
@@ -171,6 +174,7 @@ const handle202 = async <T>(
   maxRetries: number
 ): Promise<Result<T, DiscordFetchError>> => {
   let retryAfter = await parseRetryAfterFrom202(response);
+  let rateLimitAttempt = 0;
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     await sleep(retryAfter * 1000);
@@ -187,12 +191,14 @@ const handle202 = async <T>(
     if (retryResponse.status === 429) {
       const rateLimitResult = await handle429(
         retryResponse,
-        attempt,
-        maxRetries
+        rateLimitAttempt,
+        MAX_429_RETRIES
       );
       if (rateLimitResult.isErr()) {
         return rateLimitResult;
       }
+      rateLimitAttempt++;
+      attempt--;
       continue;
     }
 

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import type { z } from "zod";
+import { z } from "zod";
 import { IndexNotReadyResponseSchema } from "@/discord/schemas.ts";
 import {
   DiscordApiError,
@@ -9,6 +9,14 @@ import {
 } from "@/errors.ts";
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
+const DEFAULT_MAX_RETRIES_429 = 3;
+const DEFAULT_MAX_RETRIES_202 = 5;
+const DEFAULT_RETRY_DELAY_SECONDS = 2;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+const RateLimitBodySchema = z.object({
+  retry_after: z.number(),
+});
 
 type RateLimitState = {
   lastRequestTime: number;
@@ -58,17 +66,33 @@ const makeHeaders = (token: string) => ({
 
 const fetchWithAuth = async (
   url: string,
-  token: string
+  token: string,
+  timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
 ): Promise<Result<Response, DiscordApiError>> => {
-  return await Result.tryPromise({
-    try: () => fetch(url, { headers: makeHeaders(token) }),
-    catch: (cause) =>
-      new DiscordApiError({
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const result = await Result.tryPromise({
+    try: () =>
+      fetch(url, { headers: makeHeaders(token), signal: controller.signal }),
+    catch: (cause) => {
+      if (cause instanceof DOMException && cause.name === "AbortError") {
+        return new DiscordApiError({
+          message: `Request timed out after ${timeoutMs}ms`,
+          status: 0,
+          body: null,
+        });
+      }
+      return new DiscordApiError({
         message: `Network error: ${cause instanceof Error ? cause.message : String(cause)}`,
         status: 0,
         body: null,
-      }),
+      });
+    },
   });
+
+  clearTimeout(timer);
+  return result;
 };
 
 type DiscordFetchError =
@@ -83,7 +107,7 @@ const handle429 = async (
   maxRetries: number
 ): Promise<Result<"retry", DiscordApiError | RateLimitExhaustedError>> => {
   const bodyResult = await Result.tryPromise({
-    try: () => response.json() as Promise<{ retry_after: number }>,
+    try: () => response.json() as Promise<unknown>,
     catch: () =>
       new DiscordApiError({
         message: "Failed to parse 429 response body",
@@ -96,7 +120,18 @@ const handle429 = async (
     return bodyResult;
   }
 
-  const retryAfter = bodyResult.value.retry_after;
+  const parsed = RateLimitBodySchema.safeParse(bodyResult.value);
+  if (!parsed.success) {
+    return Result.err(
+      new DiscordApiError({
+        message: "Invalid 429 response body",
+        status: 429,
+        body: bodyResult.value,
+      })
+    );
+  }
+
+  const retryAfter = parsed.data.retry_after;
 
   if (attempt >= maxRetries) {
     return Result.err(
@@ -107,8 +142,25 @@ const handle429 = async (
     );
   }
 
-  await sleep(retryAfter * 1000);
+  const backoffMs = retryAfter * 1000 * 2 ** attempt + Math.random() * 1000;
+  await sleep(backoffMs);
   return Result.ok("retry" as const);
+};
+
+const parseRetryAfterFrom202 = async (response: Response): Promise<number> => {
+  const bodyResult = await Result.tryPromise({
+    try: () => response.json() as Promise<unknown>,
+    catch: () => null,
+  });
+
+  if (bodyResult.isErr()) {
+    return DEFAULT_RETRY_DELAY_SECONDS;
+  }
+
+  const parsed = IndexNotReadyResponseSchema.safeParse(bodyResult.value);
+  return parsed.success
+    ? parsed.data.retry_after || DEFAULT_RETRY_DELAY_SECONDS
+    : DEFAULT_RETRY_DELAY_SECONDS;
 };
 
 const handle202 = async <T>(
@@ -118,22 +170,7 @@ const handle202 = async <T>(
   schema: z.ZodType<T>,
   maxRetries: number
 ): Promise<Result<T, DiscordFetchError>> => {
-  const bodyResult = await Result.tryPromise({
-    try: () => response.json() as Promise<unknown>,
-    catch: () =>
-      new DiscordApiError({
-        message: "Failed to parse 202 response body",
-        status: 202,
-        body: null,
-      }),
-  });
-
-  if (bodyResult.isErr()) {
-    return bodyResult;
-  }
-
-  const parsed = IndexNotReadyResponseSchema.safeParse(bodyResult.value);
-  const retryAfter = parsed.success ? parsed.data.retry_after || 2 : 2;
+  let retryAfter = await parseRetryAfterFrom202(response);
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     await sleep(retryAfter * 1000);
@@ -147,9 +184,28 @@ const handle202 = async <T>(
     const retryResponse = retryResult.value;
     updateRateLimitState(retryResponse.headers);
 
-    if (retryResponse.status !== 202) {
-      return await parseResponse(retryResponse, schema);
+    if (retryResponse.status === 429) {
+      const rateLimitResult = await handle429(
+        retryResponse,
+        attempt,
+        maxRetries
+      );
+      if (rateLimitResult.isErr()) {
+        return rateLimitResult;
+      }
+      continue;
     }
+
+    if (retryResponse.status === 202) {
+      retryAfter = await parseRetryAfterFrom202(retryResponse);
+      continue;
+    }
+
+    if (!retryResponse.ok) {
+      return await handleErrorResponse(retryResponse);
+    }
+
+    return await parseResponse(retryResponse, schema);
   }
 
   return Result.err(
@@ -213,8 +269,8 @@ export const discordFetch = async <T>(
   path: string,
   schema: z.ZodType<T>,
   token: string,
-  maxRetries429 = 3,
-  maxRetries202 = 5
+  maxRetries429 = DEFAULT_MAX_RETRIES_429,
+  maxRetries202 = DEFAULT_MAX_RETRIES_202
 ): Promise<Result<T, DiscordFetchError>> => {
   const url = `${DISCORD_API_BASE}${path}`;
 

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -101,8 +101,6 @@ type DiscordFetchError =
   | IndexNotReadyError
   | ValidationError;
 
-const MAX_429_RETRIES = 5;
-
 const handle429 = async (
   response: Response,
   rateLimitAttempt: number,
@@ -171,7 +169,8 @@ const handle202 = async <T>(
   url: string,
   token: string,
   schema: z.ZodType<T>,
-  maxRetries: number
+  maxRetries: number,
+  maxRetries429: number
 ): Promise<Result<T, DiscordFetchError>> => {
   let retryAfter = await parseRetryAfterFrom202(response);
   let rateLimitAttempt = 0;
@@ -192,7 +191,7 @@ const handle202 = async <T>(
       const rateLimitResult = await handle429(
         retryResponse,
         rateLimitAttempt,
-        MAX_429_RETRIES
+        maxRetries429
       );
       if (rateLimitResult.isErr()) {
         return rateLimitResult;
@@ -300,7 +299,14 @@ export const discordFetch = async <T>(
     }
 
     if (response.status === 202) {
-      return await handle202(response, url, token, schema, maxRetries202);
+      return await handle202(
+        response,
+        url,
+        token,
+        schema,
+        maxRetries202,
+        maxRetries429
+      );
     }
 
     if (!response.ok) {

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -24,35 +24,65 @@ type RateLimitState = {
   resetAfterMs: number;
 };
 
-const rateLimitState: RateLimitState = {
-  remaining: 1,
-  resetAfterMs: 0,
-  lastRequestTime: 0,
+type BucketKey = string;
+
+const rateLimitBuckets = new Map<BucketKey, RateLimitState>();
+
+const getBucketKey = (path: string, token: string): BucketKey => {
+  const hashInput = `${path}:${token}`;
+  let hash = 0;
+  for (let i = 0; i < hashInput.length; i++) {
+    const char = hashInput.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash &= hash;
+  }
+  return `bucket:${hash}`;
+};
+
+const getBucketState = (bucketKey: BucketKey): RateLimitState => {
+  let state = rateLimitBuckets.get(bucketKey);
+  if (!state) {
+    state = {
+      lastRequestTime: 0,
+      remaining: 1,
+      resetAfterMs: 0,
+    };
+    rateLimitBuckets.set(bucketKey, state);
+  }
+  return state;
 };
 
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-const updateRateLimitState = (headers: Headers): void => {
+const updateRateLimitState = (headers: Headers, bucketKey: BucketKey): void => {
+  const state = getBucketState(bucketKey);
   const remaining = headers.get("X-RateLimit-Remaining");
   const resetAfter = headers.get("X-RateLimit-Reset-After");
+  const bucket = headers.get("X-RateLimit-Bucket");
+
+  if (bucket !== null && bucket !== bucketKey) {
+    rateLimitBuckets.delete(bucketKey);
+    rateLimitBuckets.set(bucket, state);
+  }
 
   if (remaining !== null) {
-    rateLimitState.remaining = Number.parseInt(remaining, 10);
+    state.remaining = Number.parseInt(remaining, 10);
   }
   if (resetAfter !== null) {
-    rateLimitState.resetAfterMs = Number.parseFloat(resetAfter) * 1000;
+    state.resetAfterMs = Number.parseFloat(resetAfter) * 1000;
   }
-  rateLimitState.lastRequestTime = Date.now();
+  state.lastRequestTime = Date.now();
 };
 
-const waitForRateLimit = async (): Promise<void> => {
-  if (rateLimitState.remaining > 0) {
+const waitForRateLimit = async (bucketKey: BucketKey): Promise<void> => {
+  const state = getBucketState(bucketKey);
+  if (state.remaining > 0) {
     return;
   }
 
-  const elapsed = Date.now() - rateLimitState.lastRequestTime;
-  const waitTime = rateLimitState.resetAfterMs - elapsed;
+  const elapsed = Date.now() - state.lastRequestTime;
+  const waitTime = state.resetAfterMs - elapsed;
 
   if (waitTime > 0) {
     await sleep(waitTime);
@@ -170,14 +200,15 @@ const handle202 = async <T>(
   token: string,
   schema: z.ZodType<T>,
   maxRetries: number,
-  maxRetries429: number
+  maxRetries429: number,
+  bucketKey: BucketKey
 ): Promise<Result<T, DiscordFetchError>> => {
   let retryAfter = await parseRetryAfterFrom202(response);
   let rateLimitAttempt = 0;
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     await sleep(retryAfter * 1000);
-    await waitForRateLimit();
+    await waitForRateLimit(bucketKey);
 
     const retryResult = await fetchWithAuth(url, token);
     if (retryResult.isErr()) {
@@ -185,7 +216,7 @@ const handle202 = async <T>(
     }
 
     const retryResponse = retryResult.value;
-    updateRateLimitState(retryResponse.headers);
+    updateRateLimitState(retryResponse.headers, bucketKey);
 
     if (retryResponse.status === 429) {
       const rateLimitResult = await handle429(
@@ -278,9 +309,10 @@ export const discordFetch = async <T>(
   maxRetries202 = DEFAULT_MAX_RETRIES_202
 ): Promise<Result<T, DiscordFetchError>> => {
   const url = `${DISCORD_API_BASE}${path}`;
+  const bucketKey = getBucketKey(path, token);
 
   for (let attempt = 0; attempt <= maxRetries429; attempt++) {
-    await waitForRateLimit();
+    await waitForRateLimit(bucketKey);
 
     const fetchResult = await fetchWithAuth(url, token);
     if (fetchResult.isErr()) {
@@ -288,7 +320,7 @@ export const discordFetch = async <T>(
     }
 
     const response = fetchResult.value;
-    updateRateLimitState(response.headers);
+    updateRateLimitState(response.headers, bucketKey);
 
     if (response.status === 429) {
       const result = await handle429(response, attempt, maxRetries429);
@@ -305,7 +337,8 @@ export const discordFetch = async <T>(
         token,
         schema,
         maxRetries202,
-        maxRetries429
+        maxRetries429,
+        bucketKey
       );
     }
 

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -201,7 +201,7 @@ const parseResponse = async <T>(
     return Result.err(
       new ValidationError({
         message: "Discord API response validation failed",
-        issues: parsed.error,
+        issues: parsed.error.issues,
       })
     );
   }

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -1,6 +1,9 @@
 import { Result } from "better-result";
-import { z } from "zod";
-import { IndexNotReadyResponseSchema } from "@/discord/schemas.ts";
+import type { z } from "zod";
+import {
+  IndexNotReadyResponseSchema,
+  RateLimitBodySchema,
+} from "@/discord/schemas.ts";
 import {
   DiscordApiError,
   IndexNotReadyError,
@@ -14,10 +17,6 @@ const DEFAULT_MAX_RETRIES_202 = 5;
 const DEFAULT_RETRY_DELAY_SECONDS = 2;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
-const RateLimitBodySchema = z.object({
-  retry_after: z.number(),
-});
-
 type RateLimitState = {
   lastRequestTime: number;
   remaining: number;
@@ -30,12 +29,12 @@ const rateLimitBuckets = new Map<BucketKey, RateLimitState>();
 const bucketKeyMap = new Map<BucketKey, BucketKey>();
 
 const computeBucketKey = (path: string, token: string): BucketKey => {
-  const hashInput = `${path}:${token}`;
+  const routePath = path.split("?")[0];
+  const hashInput = `${routePath}:${token}`;
   let hash = 0;
   for (let i = 0; i < hashInput.length; i++) {
     const char = hashInput.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash &= hash;
+    hash = ((hash << 5) - hash + char) >>> 0;
   }
   return `bucket:${hash}`;
 };
@@ -66,7 +65,7 @@ const updateRateLimitState = (
   const resetAfter = headers.get("X-RateLimit-Reset-After");
   const bucket = headers.get("X-RateLimit-Bucket");
 
-  if (bucket !== null && bucket !== bucketKey) {
+  if (bucket !== null && `discord:${bucket}` !== bucketKey) {
     const discordBucketKey = `discord:${bucket}`;
     rateLimitBuckets.delete(bucketKey);
     rateLimitBuckets.set(discordBucketKey, state);
@@ -85,6 +84,7 @@ const updateRateLimitState = (
 const waitForRateLimit = async (bucketKey: BucketKey): Promise<void> => {
   const state = getBucketState(bucketKey);
   if (state.remaining > 0) {
+    state.remaining--;
     return;
   }
 
@@ -104,14 +104,19 @@ const makeHeaders = (token: string) => ({
 const fetchWithAuth = async (
   url: string,
   token: string,
-  timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
+  timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  method = "GET"
 ): Promise<Result<Response, DiscordApiError>> => {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   const result = await Result.tryPromise({
     try: () =>
-      fetch(url, { headers: makeHeaders(token), signal: controller.signal }),
+      fetch(url, {
+        method,
+        headers: makeHeaders(token),
+        signal: controller.signal,
+      }),
     catch: (cause) => {
       if (cause instanceof DOMException && cause.name === "AbortError") {
         return new DiscordApiError({
@@ -197,9 +202,11 @@ const parseRetryAfterFrom202 = async (response: Response): Promise<number> => {
 
   const parsed = IndexNotReadyResponseSchema.safeParse(bodyResult.value);
   return parsed.success
-    ? parsed.data.retry_after || DEFAULT_RETRY_DELAY_SECONDS
+    ? (parsed.data.retry_after ?? DEFAULT_RETRY_DELAY_SECONDS)
     : DEFAULT_RETRY_DELAY_SECONDS;
 };
+
+type RetryCounter = { value: number };
 
 const handle202 = async <T>(
   response: Response,
@@ -209,10 +216,10 @@ const handle202 = async <T>(
   maxRetries: number,
   maxRetries429: number,
   bucketKey: BucketKey,
-  computedKey: BucketKey
+  computedKey: BucketKey,
+  rateLimitCounter: RetryCounter
 ): Promise<Result<T, DiscordFetchError>> => {
   let retryAfter = await parseRetryAfterFrom202(response);
-  let rateLimitAttempt = 0;
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     await sleep(retryAfter * 1000);
@@ -229,13 +236,13 @@ const handle202 = async <T>(
     if (retryResponse.status === 429) {
       const rateLimitResult = await handle429(
         retryResponse,
-        rateLimitAttempt,
+        rateLimitCounter.value,
         maxRetries429
       );
       if (rateLimitResult.isErr()) {
         return rateLimitResult;
       }
-      rateLimitAttempt++;
+      rateLimitCounter.value++;
       attempt--;
       continue;
     }
@@ -319,8 +326,9 @@ export const discordFetch = async <T>(
   const url = `${DISCORD_API_BASE}${path}`;
   const computedKey = computeBucketKey(path, token);
   const bucketKey = bucketKeyMap.get(computedKey) ?? computedKey;
+  const rateLimitCounter: RetryCounter = { value: 0 };
 
-  for (let attempt = 0; attempt <= maxRetries429; attempt++) {
+  for (; rateLimitCounter.value <= maxRetries429; rateLimitCounter.value++) {
     await waitForRateLimit(bucketKey);
 
     const fetchResult = await fetchWithAuth(url, token);
@@ -332,7 +340,11 @@ export const discordFetch = async <T>(
     updateRateLimitState(response.headers, bucketKey, computedKey);
 
     if (response.status === 429) {
-      const result = await handle429(response, attempt, maxRetries429);
+      const result = await handle429(
+        response,
+        rateLimitCounter.value,
+        maxRetries429
+      );
       if (result.isErr()) {
         return result;
       }
@@ -348,7 +360,8 @@ export const discordFetch = async <T>(
         maxRetries202,
         maxRetries429,
         bucketKey,
-        computedKey
+        computedKey,
+        rateLimitCounter
       );
     }
 

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -27,8 +27,9 @@ type RateLimitState = {
 type BucketKey = string;
 
 const rateLimitBuckets = new Map<BucketKey, RateLimitState>();
+const bucketKeyMap = new Map<BucketKey, BucketKey>();
 
-const getBucketKey = (path: string, token: string): BucketKey => {
+const computeBucketKey = (path: string, token: string): BucketKey => {
   const hashInput = `${path}:${token}`;
   let hash = 0;
   for (let i = 0; i < hashInput.length; i++) {
@@ -55,15 +56,21 @@ const getBucketState = (bucketKey: BucketKey): RateLimitState => {
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-const updateRateLimitState = (headers: Headers, bucketKey: BucketKey): void => {
+const updateRateLimitState = (
+  headers: Headers,
+  bucketKey: BucketKey,
+  computedKey: BucketKey
+): void => {
   const state = getBucketState(bucketKey);
   const remaining = headers.get("X-RateLimit-Remaining");
   const resetAfter = headers.get("X-RateLimit-Reset-After");
   const bucket = headers.get("X-RateLimit-Bucket");
 
   if (bucket !== null && bucket !== bucketKey) {
+    const discordBucketKey = `discord:${bucket}`;
     rateLimitBuckets.delete(bucketKey);
-    rateLimitBuckets.set(bucket, state);
+    rateLimitBuckets.set(discordBucketKey, state);
+    bucketKeyMap.set(computedKey, discordBucketKey);
   }
 
   if (remaining !== null) {
@@ -201,7 +208,8 @@ const handle202 = async <T>(
   schema: z.ZodType<T>,
   maxRetries: number,
   maxRetries429: number,
-  bucketKey: BucketKey
+  bucketKey: BucketKey,
+  computedKey: BucketKey
 ): Promise<Result<T, DiscordFetchError>> => {
   let retryAfter = await parseRetryAfterFrom202(response);
   let rateLimitAttempt = 0;
@@ -216,7 +224,7 @@ const handle202 = async <T>(
     }
 
     const retryResponse = retryResult.value;
-    updateRateLimitState(retryResponse.headers, bucketKey);
+    updateRateLimitState(retryResponse.headers, bucketKey, computedKey);
 
     if (retryResponse.status === 429) {
       const rateLimitResult = await handle429(
@@ -309,7 +317,8 @@ export const discordFetch = async <T>(
   maxRetries202 = DEFAULT_MAX_RETRIES_202
 ): Promise<Result<T, DiscordFetchError>> => {
   const url = `${DISCORD_API_BASE}${path}`;
-  const bucketKey = getBucketKey(path, token);
+  const computedKey = computeBucketKey(path, token);
+  const bucketKey = bucketKeyMap.get(computedKey) ?? computedKey;
 
   for (let attempt = 0; attempt <= maxRetries429; attempt++) {
     await waitForRateLimit(bucketKey);
@@ -320,7 +329,7 @@ export const discordFetch = async <T>(
     }
 
     const response = fetchResult.value;
-    updateRateLimitState(response.headers, bucketKey);
+    updateRateLimitState(response.headers, bucketKey, computedKey);
 
     if (response.status === 429) {
       const result = await handle429(response, attempt, maxRetries429);
@@ -338,7 +347,8 @@ export const discordFetch = async <T>(
         schema,
         maxRetries202,
         maxRetries429,
-        bucketKey
+        bucketKey,
+        computedKey
       );
     }
 

--- a/src/discord/schemas.ts
+++ b/src/discord/schemas.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const MAX_OFFSET = 9975;
+export const MAX_PAGE_SIZE = 25;
+
 // Embed sub-objects
 
 export const EmbedFooterSchema = z.object({
@@ -105,13 +108,41 @@ export const MessageSchema = z.object({
     .optional(),
 });
 
+export const ThreadSchema = z.object({
+  id: z.string(),
+  type: z.number(),
+  name: z.string().optional(),
+  guild_id: z.string().optional(),
+  parent_id: z.string().nullable().optional(),
+  message_count: z.number().optional(),
+  member_count: z.number().optional(),
+  thread_metadata: z
+    .object({
+      archived: z.boolean(),
+      auto_archive_duration: z.number().optional(),
+      archive_timestamp: z.string().optional(),
+      locked: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+export const MemberSchema = z.object({
+  user_id: z.string().optional(),
+  nick: z.string().nullable().optional(),
+  avatar: z.string().nullable().optional(),
+  roles: z.array(z.string()).optional(),
+  joined_at: z.string().optional(),
+  deaf: z.boolean().optional(),
+  mute: z.boolean().optional(),
+});
+
 export const SearchResponseSchema = z.object({
   total_results: z.number(),
   messages: z.array(z.array(MessageSchema)),
   doing_deep_historical_index: z.boolean().optional(),
   documents_indexed: z.number().optional(),
-  threads: z.array(z.unknown()).optional(),
-  members: z.array(z.unknown()).optional(),
+  threads: z.array(ThreadSchema).optional(),
+  members: z.array(MemberSchema).optional(),
 });
 
 export const IndexNotReadyResponseSchema = z.object({
@@ -158,11 +189,11 @@ export const SearchParamsSchema = z.object({
   pinned: z.boolean().optional(),
   repliedToMessageId: z.array(z.string()).optional(),
   repliedToUserId: z.array(z.string()).optional(),
-  slop: z.number().optional(),
+  slop: z.number().int().min(0).optional(),
   sortBy: z.enum(["timestamp", "relevance"]).optional(),
   sortOrder: z.enum(["asc", "desc"]).optional(),
-  offset: z.number().optional(),
-  limit: z.number().optional(),
+  offset: z.number().int().min(0).max(MAX_OFFSET).optional(),
+  limit: z.number().int().min(1).max(MAX_PAGE_SIZE).optional(),
 });
 
 // Inferred types
@@ -170,6 +201,8 @@ export type Embed = z.infer<typeof EmbedSchema>;
 export type EmbedField = z.infer<typeof EmbedFieldSchema>;
 export type User = z.infer<typeof UserSchema>;
 export type Message = z.infer<typeof MessageSchema>;
+export type Thread = z.infer<typeof ThreadSchema>;
+export type Member = z.infer<typeof MemberSchema>;
 export type SearchResponse = z.infer<typeof SearchResponseSchema>;
 export type IndexNotReadyResponse = z.infer<typeof IndexNotReadyResponseSchema>;
 export type SearchParams = z.infer<typeof SearchParamsSchema>;

--- a/src/discord/schemas.ts
+++ b/src/discord/schemas.ts
@@ -1,0 +1,175 @@
+import { z } from "zod";
+
+// Embed sub-objects
+
+export const EmbedFooterSchema = z.object({
+  text: z.string(),
+  icon_url: z.string().optional(),
+  proxy_icon_url: z.string().optional(),
+});
+
+export const EmbedImageSchema = z.object({
+  url: z.string(),
+  proxy_url: z.string().optional(),
+  height: z.number().optional(),
+  width: z.number().optional(),
+});
+
+export const EmbedThumbnailSchema = z.object({
+  url: z.string(),
+  proxy_url: z.string().optional(),
+  height: z.number().optional(),
+  width: z.number().optional(),
+});
+
+export const EmbedVideoSchema = z.object({
+  url: z.string().optional(),
+  proxy_url: z.string().optional(),
+  height: z.number().optional(),
+  width: z.number().optional(),
+});
+
+export const EmbedProviderSchema = z.object({
+  name: z.string().optional(),
+  url: z.string().optional(),
+});
+
+export const EmbedAuthorSchema = z.object({
+  name: z.string(),
+  url: z.string().optional(),
+  icon_url: z.string().optional(),
+  proxy_icon_url: z.string().optional(),
+});
+
+export const EmbedFieldSchema = z.object({
+  name: z.string(),
+  value: z.string(),
+  inline: z.boolean().optional(),
+});
+
+export const EmbedSchema = z.object({
+  title: z.string().optional(),
+  type: z.string().optional(),
+  description: z.string().optional(),
+  url: z.string().optional(),
+  timestamp: z.string().optional(),
+  color: z.number().optional(),
+  footer: EmbedFooterSchema.optional(),
+  image: EmbedImageSchema.optional(),
+  thumbnail: EmbedThumbnailSchema.optional(),
+  video: EmbedVideoSchema.optional(),
+  provider: EmbedProviderSchema.optional(),
+  author: EmbedAuthorSchema.optional(),
+  fields: z.array(EmbedFieldSchema).optional(),
+});
+
+export const UserSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  discriminator: z.string().optional(),
+  avatar: z.string().nullable().optional(),
+  bot: z.boolean().optional(),
+});
+
+export const AttachmentSchema = z.object({
+  id: z.string(),
+  filename: z.string(),
+  size: z.number(),
+  url: z.string(),
+  proxy_url: z.string().optional(),
+  content_type: z.string().optional(),
+});
+
+export const MessageSchema = z.object({
+  id: z.string(),
+  channel_id: z.string(),
+  author: UserSchema,
+  content: z.string(),
+  timestamp: z.string(),
+  edited_timestamp: z.string().nullable().optional(),
+  tts: z.boolean().optional(),
+  mention_everyone: z.boolean().optional(),
+  mentions: z.array(UserSchema).optional(),
+  pinned: z.boolean().optional(),
+  type: z.number().optional(),
+  embeds: z.array(EmbedSchema).optional(),
+  attachments: z.array(AttachmentSchema).optional(),
+  referenced_message: z
+    .object({
+      id: z.string(),
+      channel_id: z.string(),
+      author: UserSchema.optional(),
+      content: z.string().optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+export const SearchResponseSchema = z.object({
+  total_results: z.number(),
+  messages: z.array(z.array(MessageSchema)),
+  doing_deep_historical_index: z.boolean().optional(),
+  documents_indexed: z.number().optional(),
+  threads: z.array(z.unknown()).optional(),
+  members: z.array(z.unknown()).optional(),
+});
+
+export const IndexNotReadyResponseSchema = z.object({
+  message: z.string(),
+  code: z.number(),
+  documents_indexed: z.number().optional(),
+  retry_after: z.number(),
+});
+
+export const SearchParamsSchema = z.object({
+  attachmentExtension: z.array(z.string()).optional(),
+  attachmentFilename: z.array(z.string()).optional(),
+  authorId: z.array(z.string()).optional(),
+  authorType: z.array(z.enum(["user", "bot", "webhook"])).optional(),
+  channelId: z.array(z.string()).optional(),
+  content: z.string().optional(),
+  embedProvider: z.array(z.string()).optional(),
+  embedType: z
+    .array(z.enum(["image", "video", "gif", "sound", "article"]))
+    .optional(),
+  guildId: z.string(),
+  has: z
+    .array(
+      z.enum([
+        "image",
+        "sound",
+        "video",
+        "file",
+        "sticker",
+        "embed",
+        "link",
+        "poll",
+        "snapshot",
+      ])
+    )
+    .optional(),
+  includeNsfw: z.boolean().optional(),
+  linkHostname: z.array(z.string()).optional(),
+  maxId: z.string().optional(),
+  mentionEveryone: z.boolean().optional(),
+  mentions: z.array(z.string()).optional(),
+  mentionsRoleId: z.array(z.string()).optional(),
+  minId: z.string().optional(),
+  pinned: z.boolean().optional(),
+  repliedToMessageId: z.array(z.string()).optional(),
+  repliedToUserId: z.array(z.string()).optional(),
+  slop: z.number().optional(),
+  sortBy: z.enum(["timestamp", "relevance"]).optional(),
+  sortOrder: z.enum(["asc", "desc"]).optional(),
+  offset: z.number().optional(),
+  limit: z.number().optional(),
+});
+
+// Inferred types
+export type Embed = z.infer<typeof EmbedSchema>;
+export type EmbedField = z.infer<typeof EmbedFieldSchema>;
+export type User = z.infer<typeof UserSchema>;
+export type Message = z.infer<typeof MessageSchema>;
+export type SearchResponse = z.infer<typeof SearchResponseSchema>;
+export type IndexNotReadyResponse = z.infer<typeof IndexNotReadyResponseSchema>;
+export type SearchParams = z.infer<typeof SearchParamsSchema>;

--- a/src/discord/schemas.ts
+++ b/src/discord/schemas.ts
@@ -12,14 +12,7 @@ const snowflakeSchema = z
   })
   .max(20, { message: "Discord ID exceeds maximum length of 20 characters" });
 
-const snowflakeArraySchema = z.array(
-  z
-    .string()
-    .regex(SNOWFLAKE_REGEX, {
-      message: "Invalid Discord ID: must be a 17-20 digit numeric snowflake",
-    })
-    .max(20, { message: "Discord ID exceeds maximum length of 20 characters" })
-);
+const snowflakeArraySchema = z.array(snowflakeSchema);
 
 // Embed sub-objects
 
@@ -29,19 +22,15 @@ export const EmbedFooterSchema = z.object({
   proxy_icon_url: z.string().optional(),
 });
 
-export const EmbedImageSchema = z.object({
+const EmbedMediaSchema = z.object({
   url: z.string(),
   proxy_url: z.string().optional(),
   height: z.number().optional(),
   width: z.number().optional(),
 });
 
-export const EmbedThumbnailSchema = z.object({
-  url: z.string(),
-  proxy_url: z.string().optional(),
-  height: z.number().optional(),
-  width: z.number().optional(),
-});
+export const EmbedImageSchema = EmbedMediaSchema;
+export const EmbedThumbnailSchema = EmbedMediaSchema;
 
 export const EmbedVideoSchema = z.object({
   url: z.string().optional(),
@@ -104,6 +93,7 @@ export const AttachmentSchema = z.object({
 export const MessageSchema = z.object({
   id: snowflakeSchema,
   channel_id: snowflakeSchema,
+  guild_id: snowflakeSchema.optional(),
   author: UserSchema,
   content: z.string(),
   timestamp: z.string(),
@@ -161,6 +151,10 @@ export const SearchResponseSchema = z.object({
   documents_indexed: z.number().optional(),
   threads: z.array(ThreadSchema).optional(),
   members: z.array(MemberSchema).optional(),
+});
+
+export const RateLimitBodySchema = z.object({
+  retry_after: z.number(),
 });
 
 export const IndexNotReadyResponseSchema = z.object({

--- a/src/discord/schemas.ts
+++ b/src/discord/schemas.ts
@@ -3,6 +3,24 @@ import { z } from "zod";
 export const MAX_OFFSET = 9975;
 export const MAX_PAGE_SIZE = 25;
 
+const SNOWFLAKE_REGEX = /^\d{17,20}$/;
+
+const snowflakeSchema = z
+  .string()
+  .regex(SNOWFLAKE_REGEX, {
+    message: "Invalid Discord ID: must be a 17-20 digit numeric snowflake",
+  })
+  .max(20, { message: "Discord ID exceeds maximum length of 20 characters" });
+
+const snowflakeArraySchema = z.array(
+  z
+    .string()
+    .regex(SNOWFLAKE_REGEX, {
+      message: "Invalid Discord ID: must be a 17-20 digit numeric snowflake",
+    })
+    .max(20, { message: "Discord ID exceeds maximum length of 20 characters" })
+);
+
 // Embed sub-objects
 
 export const EmbedFooterSchema = z.object({
@@ -67,7 +85,7 @@ export const EmbedSchema = z.object({
 });
 
 export const UserSchema = z.object({
-  id: z.string(),
+  id: snowflakeSchema,
   username: z.string(),
   discriminator: z.string().optional(),
   avatar: z.string().nullable().optional(),
@@ -75,7 +93,7 @@ export const UserSchema = z.object({
 });
 
 export const AttachmentSchema = z.object({
-  id: z.string(),
+  id: snowflakeSchema,
   filename: z.string(),
   size: z.number(),
   url: z.string(),
@@ -84,8 +102,8 @@ export const AttachmentSchema = z.object({
 });
 
 export const MessageSchema = z.object({
-  id: z.string(),
-  channel_id: z.string(),
+  id: snowflakeSchema,
+  channel_id: snowflakeSchema,
   author: UserSchema,
   content: z.string(),
   timestamp: z.string(),
@@ -99,8 +117,8 @@ export const MessageSchema = z.object({
   attachments: z.array(AttachmentSchema).optional(),
   referenced_message: z
     .object({
-      id: z.string(),
-      channel_id: z.string(),
+      id: snowflakeSchema,
+      channel_id: snowflakeSchema,
       author: UserSchema.optional(),
       content: z.string().optional(),
     })
@@ -109,11 +127,11 @@ export const MessageSchema = z.object({
 });
 
 export const ThreadSchema = z.object({
-  id: z.string(),
+  id: snowflakeSchema,
   type: z.number(),
   name: z.string().optional(),
-  guild_id: z.string().optional(),
-  parent_id: z.string().nullable().optional(),
+  guild_id: snowflakeSchema.optional(),
+  parent_id: snowflakeSchema.nullable().optional(),
   message_count: z.number().optional(),
   member_count: z.number().optional(),
   thread_metadata: z
@@ -127,10 +145,10 @@ export const ThreadSchema = z.object({
 });
 
 export const MemberSchema = z.object({
-  user_id: z.string().optional(),
+  user_id: snowflakeSchema.optional(),
   nick: z.string().nullable().optional(),
   avatar: z.string().nullable().optional(),
-  roles: z.array(z.string()).optional(),
+  roles: z.array(snowflakeSchema).optional(),
   joined_at: z.string().optional(),
   deaf: z.boolean().optional(),
   mute: z.boolean().optional(),
@@ -155,15 +173,15 @@ export const IndexNotReadyResponseSchema = z.object({
 export const SearchParamsSchema = z.object({
   attachmentExtension: z.array(z.string()).optional(),
   attachmentFilename: z.array(z.string()).optional(),
-  authorId: z.array(z.string()).optional(),
+  authorId: snowflakeArraySchema.optional(),
   authorType: z.array(z.enum(["user", "bot", "webhook"])).optional(),
-  channelId: z.array(z.string()).optional(),
+  channelId: snowflakeArraySchema.optional(),
   content: z.string().optional(),
   embedProvider: z.array(z.string()).optional(),
   embedType: z
     .array(z.enum(["image", "video", "gif", "sound", "article"]))
     .optional(),
-  guildId: z.string(),
+  guildId: snowflakeSchema,
   has: z
     .array(
       z.enum([
@@ -181,14 +199,14 @@ export const SearchParamsSchema = z.object({
     .optional(),
   includeNsfw: z.boolean().optional(),
   linkHostname: z.array(z.string()).optional(),
-  maxId: z.string().optional(),
+  maxId: snowflakeSchema.optional(),
   mentionEveryone: z.boolean().optional(),
-  mentions: z.array(z.string()).optional(),
-  mentionsRoleId: z.array(z.string()).optional(),
-  minId: z.string().optional(),
+  mentions: snowflakeArraySchema.optional(),
+  mentionsRoleId: snowflakeArraySchema.optional(),
+  minId: snowflakeSchema.optional(),
   pinned: z.boolean().optional(),
-  repliedToMessageId: z.array(z.string()).optional(),
-  repliedToUserId: z.array(z.string()).optional(),
+  repliedToMessageId: snowflakeArraySchema.optional(),
+  repliedToUserId: snowflakeArraySchema.optional(),
   slop: z.number().int().min(0).optional(),
   sortBy: z.enum(["timestamp", "relevance"]).optional(),
   sortOrder: z.enum(["asc", "desc"]).optional(),

--- a/src/discord/search.ts
+++ b/src/discord/search.ts
@@ -158,7 +158,7 @@ const fetchPage = async (
     ? Math.min(params.limit, DEFAULT_PAGE_SIZE)
     : DEFAULT_PAGE_SIZE;
 
-  if (offset === 0 && !maxId) {
+  if (state.totalResults === 0) {
     state.totalResults = maxMessages
       ? Math.min(data.total_results, maxMessages)
       : data.total_results;
@@ -267,7 +267,7 @@ export const searchAllMessages = async (
     searchParams: { ...queryParams, sortBy: "timestamp", sortOrder: "desc" },
     token,
     startOffset: queryParams.offset ?? 0,
-    maxMessages: queryParams.limit,
+    maxMessages: undefined,
     pageSize: queryParams.limit
       ? Math.min(queryParams.limit, DEFAULT_PAGE_SIZE)
       : DEFAULT_PAGE_SIZE,

--- a/src/discord/search.ts
+++ b/src/discord/search.ts
@@ -2,6 +2,7 @@ import { Ok, Result } from "better-result";
 import { discordFetch } from "@/discord/client.ts";
 import {
   MAX_OFFSET,
+  MAX_PAGE_SIZE,
   type Message,
   type SearchParams,
   SearchParamsSchema,
@@ -14,8 +15,6 @@ import type {
   RateLimitExhaustedError,
 } from "@/errors.ts";
 import { ValidationError } from "@/errors.ts";
-
-const DEFAULT_PAGE_SIZE = 25;
 
 const validateSearchParams = (
   params: unknown
@@ -45,8 +44,8 @@ const buildQueryString = (
 ): string => {
   const qs = new URLSearchParams();
   const pageSize = params.limit
-    ? Math.min(params.limit, DEFAULT_PAGE_SIZE)
-    : DEFAULT_PAGE_SIZE;
+    ? Math.min(params.limit, MAX_PAGE_SIZE)
+    : MAX_PAGE_SIZE;
 
   qs.set("limit", String(pageSize));
   qs.set("offset", String(offset));
@@ -110,6 +109,19 @@ const buildQueryString = (
   return qs.toString();
 };
 
+const fetchSearch = async (
+  params: SearchParams,
+  token: string,
+  offset: number,
+  maxId?: string
+): Promise<Result<SearchResponse, SearchError>> => {
+  const queryString = buildQueryString(params, offset, maxId);
+  const encodedGuildId = encodeURIComponent(params.guildId);
+  const path = `/guilds/${encodedGuildId}/messages/search?${queryString}`;
+
+  return await discordFetch(path, SearchResponseSchema, token);
+};
+
 export const searchMessages = async (
   params: unknown,
   token: string,
@@ -121,12 +133,7 @@ export const searchMessages = async (
     return validatedParams;
   }
 
-  const queryParams = validatedParams.value;
-  const queryString = buildQueryString(queryParams, offset, maxId);
-  const encodedGuildId = encodeURIComponent(queryParams.guildId);
-  const path = `/guilds/${encodedGuildId}/messages/search?${queryString}`;
-
-  return await discordFetch(path, SearchResponseSchema, token);
+  return await fetchSearch(validatedParams.value, token, offset, maxId);
 };
 
 export type SearchProgress = { fetched: number; total: number };
@@ -148,15 +155,15 @@ const fetchPage = async (
   onProgress?: ProgressCallback,
   onPage?: PageCallback
 ): Promise<Result<"done" | "continue" | "break", SearchError>> => {
-  const result = await searchMessages(params, token, offset, maxId);
+  const result = await fetchSearch(params, token, offset, maxId);
   if (result.isErr()) {
     return result;
   }
 
   const data = result.value;
   const pageSize = params.limit
-    ? Math.min(params.limit, DEFAULT_PAGE_SIZE)
-    : DEFAULT_PAGE_SIZE;
+    ? Math.min(params.limit, MAX_PAGE_SIZE)
+    : MAX_PAGE_SIZE;
 
   if (state.totalResults === 0) {
     state.totalResults = maxMessages
@@ -255,7 +262,8 @@ export const searchAllMessages = async (
   params: unknown,
   token: string,
   onProgress?: ProgressCallback,
-  onPage?: PageCallback
+  onPage?: PageCallback,
+  maxMessages?: number
 ): Promise<Result<Message[], SearchError>> => {
   const validatedParams = validateSearchParams(params);
   if (validatedParams.isErr()) {
@@ -263,14 +271,35 @@ export const searchAllMessages = async (
   }
 
   const queryParams = validatedParams.value;
+
+  if (queryParams.sortBy && queryParams.sortBy !== "timestamp") {
+    return Result.err(
+      new ValidationError({
+        message:
+          "searchAllMessages requires sortBy: 'timestamp' for snowflake-based pagination",
+        issues: [],
+      })
+    );
+  }
+
+  if (queryParams.sortOrder && queryParams.sortOrder !== "desc") {
+    return Result.err(
+      new ValidationError({
+        message:
+          "searchAllMessages requires sortOrder: 'desc' for snowflake-based pagination",
+        issues: [],
+      })
+    );
+  }
+
   const config: PaginationConfig = {
     searchParams: { ...queryParams, sortBy: "timestamp", sortOrder: "desc" },
     token,
     startOffset: queryParams.offset ?? 0,
-    maxMessages: undefined,
+    maxMessages,
     pageSize: queryParams.limit
-      ? Math.min(queryParams.limit, DEFAULT_PAGE_SIZE)
-      : DEFAULT_PAGE_SIZE,
+      ? Math.min(queryParams.limit, MAX_PAGE_SIZE)
+      : MAX_PAGE_SIZE,
     onProgress,
     onPage,
   };

--- a/src/discord/search.ts
+++ b/src/discord/search.ts
@@ -1,0 +1,254 @@
+import { Ok, type Result } from "better-result";
+import { discordFetch } from "@/discord/client.ts";
+import {
+  type Message,
+  type SearchParams,
+  type SearchResponse,
+  SearchResponseSchema,
+} from "@/discord/schemas.ts";
+import type {
+  DiscordApiError,
+  IndexNotReadyError,
+  RateLimitExhaustedError,
+  ValidationError,
+} from "@/errors.ts";
+
+type SearchError =
+  | DiscordApiError
+  | RateLimitExhaustedError
+  | IndexNotReadyError
+  | ValidationError;
+
+const buildQueryString = (
+  params: SearchParams,
+  offset: number,
+  maxId?: string
+): string => {
+  const qs = new URLSearchParams();
+  const pageSize = params.limit ? Math.min(params.limit, 25) : 25;
+
+  qs.set("limit", String(pageSize));
+  qs.set("offset", String(offset));
+
+  if (params.content) {
+    qs.set("content", params.content);
+  }
+  if (params.pinned !== undefined) {
+    qs.set("pinned", String(params.pinned));
+  }
+  if (params.mentionEveryone !== undefined) {
+    qs.set("mention_everyone", String(params.mentionEveryone));
+  }
+  if (params.sortBy) {
+    qs.set("sort_by", params.sortBy);
+  }
+  if (params.sortOrder) {
+    qs.set("sort_order", params.sortOrder);
+  }
+  if (params.includeNsfw !== undefined) {
+    qs.set("include_nsfw", String(params.includeNsfw));
+  }
+  if (params.slop !== undefined) {
+    qs.set("slop", String(params.slop));
+  }
+
+  // Use override maxId for snowflake partitioning, otherwise use params
+  const effectiveMaxId = maxId ?? params.maxId;
+  if (effectiveMaxId) {
+    qs.set("max_id", effectiveMaxId);
+  }
+  if (params.minId) {
+    qs.set("min_id", params.minId);
+  }
+
+  // Array params
+  const arrayParams: [string, string[] | undefined][] = [
+    ["channel_id", params.channelId],
+    ["author_id", params.authorId],
+    ["author_type", params.authorType],
+    ["mentions", params.mentions],
+    ["mentions_role_id", params.mentionsRoleId],
+    ["replied_to_user_id", params.repliedToUserId],
+    ["replied_to_message_id", params.repliedToMessageId],
+    ["has", params.has],
+    ["embed_type", params.embedType],
+    ["embed_provider", params.embedProvider],
+    ["link_hostname", params.linkHostname],
+    ["attachment_filename", params.attachmentFilename],
+    ["attachment_extension", params.attachmentExtension],
+  ];
+
+  for (const [key, values] of arrayParams) {
+    if (values) {
+      for (const value of values) {
+        qs.append(key, value);
+      }
+    }
+  }
+
+  return qs.toString();
+};
+
+export const searchMessages = async (
+  params: SearchParams,
+  token: string,
+  offset = 0,
+  maxId?: string
+): Promise<Result<SearchResponse, SearchError>> => {
+  const queryString = buildQueryString(params, offset, maxId);
+  const path = `/guilds/${params.guildId}/messages/search?${queryString}`;
+
+  return await discordFetch(path, SearchResponseSchema, token);
+};
+
+export type ProgressCallback = (fetched: number, total: number) => void;
+export type PageCallback = (messages: Message[]) => void;
+
+type PaginationState = {
+  allMessages: Message[];
+  totalResults: number;
+};
+
+const fetchPage = async (
+  params: SearchParams,
+  token: string,
+  offset: number,
+  maxId: string | undefined,
+  state: PaginationState,
+  maxMessages: number | undefined,
+  onProgress?: ProgressCallback,
+  onPage?: PageCallback
+): Promise<Result<"done" | "continue" | "break", SearchError>> => {
+  const result = await searchMessages(params, token, offset, maxId);
+  if (result.isErr()) {
+    return result;
+  }
+
+  const data = result.value;
+  const pageSize = params.limit ? Math.min(params.limit, 25) : 25;
+
+  if (offset === 0 && !maxId) {
+    state.totalResults = maxMessages
+      ? Math.min(data.total_results, maxMessages)
+      : data.total_results;
+  }
+
+  let pageMessages = data.messages
+    .map((group) => group[0])
+    .filter((msg): msg is Message => msg !== undefined);
+
+  if (pageMessages.length === 0) {
+    onProgress?.(state.allMessages.length, state.totalResults);
+    return new Ok("done" as const);
+  }
+
+  // Truncate if adding this page would exceed the limit
+  if (
+    maxMessages &&
+    state.allMessages.length + pageMessages.length > maxMessages
+  ) {
+    pageMessages = pageMessages.slice(
+      0,
+      maxMessages - state.allMessages.length
+    );
+  }
+
+  state.allMessages.push(...pageMessages);
+  onPage?.(pageMessages);
+  onProgress?.(state.allMessages.length, state.totalResults);
+
+  if (state.allMessages.length >= state.totalResults) {
+    return new Ok("done" as const);
+  }
+
+  if (pageMessages.length < pageSize) {
+    return new Ok("break" as const);
+  }
+
+  return new Ok("continue" as const);
+};
+
+type PaginationConfig = {
+  searchParams: SearchParams;
+  token: string;
+  startOffset: number;
+  maxMessages: number | undefined;
+  pageSize: number;
+  onProgress?: ProgressCallback;
+  onPage?: PageCallback;
+};
+
+const fetchPartition = async (
+  config: PaginationConfig,
+  state: PaginationState,
+  maxId: string | undefined
+): Promise<Result<"done" | "continue", SearchError>> => {
+  const initialOffset = maxId ? 0 : config.startOffset;
+
+  for (let offset = initialOffset; offset <= 9975; offset += config.pageSize) {
+    const pageResult = await fetchPage(
+      config.searchParams,
+      config.token,
+      offset,
+      maxId,
+      state,
+      config.maxMessages,
+      config.onProgress,
+      config.onPage
+    );
+    if (pageResult.isErr()) {
+      return pageResult;
+    }
+    if (pageResult.value === "done") {
+      return new Ok("done" as const);
+    }
+    if (pageResult.value === "break") {
+      break;
+    }
+  }
+
+  return new Ok("continue" as const);
+};
+
+export const searchAllMessages = async (
+  params: SearchParams,
+  token: string,
+  onProgress?: ProgressCallback,
+  onPage?: PageCallback
+): Promise<Result<Message[], SearchError>> => {
+  const config: PaginationConfig = {
+    searchParams: { ...params, sortBy: "timestamp", sortOrder: "desc" },
+    token,
+    startOffset: params.offset ?? 0,
+    maxMessages: params.limit,
+    pageSize: params.limit ? Math.min(params.limit, 25) : 25,
+    onProgress,
+    onPage,
+  };
+
+  const state: PaginationState = { allMessages: [], totalResults: 0 };
+  let currentMaxId: string | undefined;
+
+  while (true) {
+    const result = await fetchPartition(config, state, currentMaxId);
+    if (result.isErr()) {
+      return result;
+    }
+    if (result.value === "done") {
+      break;
+    }
+
+    if (state.allMessages.length >= state.totalResults) {
+      break;
+    }
+
+    const lastMessage = state.allMessages.at(-1);
+    if (!lastMessage || currentMaxId === lastMessage.id) {
+      break;
+    }
+
+    currentMaxId = lastMessage.id;
+  }
+
+  return new Ok(state.allMessages);
+};

--- a/src/discord/search.ts
+++ b/src/discord/search.ts
@@ -1,6 +1,7 @@
 import { Ok, type Result } from "better-result";
 import { discordFetch } from "@/discord/client.ts";
 import {
+  MAX_OFFSET,
   type Message,
   type SearchParams,
   type SearchResponse,
@@ -12,6 +13,8 @@ import type {
   RateLimitExhaustedError,
   ValidationError,
 } from "@/errors.ts";
+
+const DEFAULT_PAGE_SIZE = 25;
 
 type SearchError =
   | DiscordApiError
@@ -25,7 +28,9 @@ const buildQueryString = (
   maxId?: string
 ): string => {
   const qs = new URLSearchParams();
-  const pageSize = params.limit ? Math.min(params.limit, 25) : 25;
+  const pageSize = params.limit
+    ? Math.min(params.limit, DEFAULT_PAGE_SIZE)
+    : DEFAULT_PAGE_SIZE;
 
   qs.set("limit", String(pageSize));
   qs.set("offset", String(offset));
@@ -101,7 +106,8 @@ export const searchMessages = async (
   return await discordFetch(path, SearchResponseSchema, token);
 };
 
-export type ProgressCallback = (fetched: number, total: number) => void;
+export type SearchProgress = { fetched: number; total: number };
+export type ProgressCallback = (progress: SearchProgress) => void;
 export type PageCallback = (messages: Message[]) => void;
 
 type PaginationState = {
@@ -125,7 +131,9 @@ const fetchPage = async (
   }
 
   const data = result.value;
-  const pageSize = params.limit ? Math.min(params.limit, 25) : 25;
+  const pageSize = params.limit
+    ? Math.min(params.limit, DEFAULT_PAGE_SIZE)
+    : DEFAULT_PAGE_SIZE;
 
   if (offset === 0 && !maxId) {
     state.totalResults = maxMessages
@@ -138,7 +146,10 @@ const fetchPage = async (
     .filter((msg): msg is Message => msg !== undefined);
 
   if (pageMessages.length === 0) {
-    onProgress?.(state.allMessages.length, state.totalResults);
+    onProgress?.({
+      fetched: state.allMessages.length,
+      total: state.totalResults,
+    });
     return new Ok("done" as const);
   }
 
@@ -153,9 +164,12 @@ const fetchPage = async (
     );
   }
 
-  state.allMessages.push(...pageMessages);
+  Array.prototype.push.apply(state.allMessages, pageMessages);
   onPage?.(pageMessages);
-  onProgress?.(state.allMessages.length, state.totalResults);
+  onProgress?.({
+    fetched: state.allMessages.length,
+    total: state.totalResults,
+  });
 
   if (state.allMessages.length >= state.totalResults) {
     return new Ok("done" as const);
@@ -185,7 +199,11 @@ const fetchPartition = async (
 ): Promise<Result<"done" | "continue", SearchError>> => {
   const initialOffset = maxId ? 0 : config.startOffset;
 
-  for (let offset = initialOffset; offset <= 9975; offset += config.pageSize) {
+  for (
+    let offset = initialOffset;
+    offset <= MAX_OFFSET;
+    offset += config.pageSize
+  ) {
     const pageResult = await fetchPage(
       config.searchParams,
       config.token,
@@ -221,7 +239,9 @@ export const searchAllMessages = async (
     token,
     startOffset: params.offset ?? 0,
     maxMessages: params.limit,
-    pageSize: params.limit ? Math.min(params.limit, 25) : 25,
+    pageSize: params.limit
+      ? Math.min(params.limit, DEFAULT_PAGE_SIZE)
+      : DEFAULT_PAGE_SIZE,
     onProgress,
     onPage,
   };

--- a/src/discord/search.ts
+++ b/src/discord/search.ts
@@ -1,9 +1,10 @@
-import { Ok, type Result } from "better-result";
+import { Ok, Result } from "better-result";
 import { discordFetch } from "@/discord/client.ts";
 import {
   MAX_OFFSET,
   type Message,
   type SearchParams,
+  SearchParamsSchema,
   type SearchResponse,
   SearchResponseSchema,
 } from "@/discord/schemas.ts";
@@ -11,10 +12,25 @@ import type {
   DiscordApiError,
   IndexNotReadyError,
   RateLimitExhaustedError,
-  ValidationError,
 } from "@/errors.ts";
+import { ValidationError } from "@/errors.ts";
 
 const DEFAULT_PAGE_SIZE = 25;
+
+const validateSearchParams = (
+  params: unknown
+): Result<SearchParams, ValidationError> => {
+  const parsed = SearchParamsSchema.safeParse(params);
+  if (!parsed.success) {
+    return Result.err(
+      new ValidationError({
+        message: "Invalid search parameters",
+        issues: parsed.error.issues,
+      })
+    );
+  }
+  return Result.ok(parsed.data);
+};
 
 type SearchError =
   | DiscordApiError
@@ -95,13 +111,20 @@ const buildQueryString = (
 };
 
 export const searchMessages = async (
-  params: SearchParams,
+  params: unknown,
   token: string,
   offset = 0,
   maxId?: string
 ): Promise<Result<SearchResponse, SearchError>> => {
-  const queryString = buildQueryString(params, offset, maxId);
-  const path = `/guilds/${params.guildId}/messages/search?${queryString}`;
+  const validatedParams = validateSearchParams(params);
+  if (validatedParams.isErr()) {
+    return validatedParams;
+  }
+
+  const queryParams = validatedParams.value;
+  const queryString = buildQueryString(queryParams, offset, maxId);
+  const encodedGuildId = encodeURIComponent(queryParams.guildId);
+  const path = `/guilds/${encodedGuildId}/messages/search?${queryString}`;
 
   return await discordFetch(path, SearchResponseSchema, token);
 };
@@ -229,18 +252,24 @@ const fetchPartition = async (
 };
 
 export const searchAllMessages = async (
-  params: SearchParams,
+  params: unknown,
   token: string,
   onProgress?: ProgressCallback,
   onPage?: PageCallback
 ): Promise<Result<Message[], SearchError>> => {
+  const validatedParams = validateSearchParams(params);
+  if (validatedParams.isErr()) {
+    return validatedParams;
+  }
+
+  const queryParams = validatedParams.value;
   const config: PaginationConfig = {
-    searchParams: { ...params, sortBy: "timestamp", sortOrder: "desc" },
+    searchParams: { ...queryParams, sortBy: "timestamp", sortOrder: "desc" },
     token,
-    startOffset: params.offset ?? 0,
-    maxMessages: params.limit,
-    pageSize: params.limit
-      ? Math.min(params.limit, DEFAULT_PAGE_SIZE)
+    startOffset: queryParams.offset ?? 0,
+    maxMessages: queryParams.limit,
+    pageSize: queryParams.limit
+      ? Math.min(queryParams.limit, DEFAULT_PAGE_SIZE)
       : DEFAULT_PAGE_SIZE,
     onProgress,
     onPage,


### PR DESCRIPTION
## Summary
- Add Zod schemas for Discord API contracts (users, messages, embeds, search)
- Add HTTP client with automatic rate limit handling, exponential backoff, and retry logic
- Add paginated search with snowflake-based partitioning for large datasets

## Stacked PR Chain
This is **PR 3 of 7** — merge in order.
`main` ← PR1 ← PR2 ← **PR3** ← PR4 ← PR5 ← PR6 ← PR7

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes linting
- [x] Rate limit headers are properly tracked
- [x] 429/202 responses trigger appropriate retry logic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a typed Discord API layer with rate limiting, retries, and paginated search. Enables reliable large-scale message fetching with automatic backoff and schema validation.

- **New Features**
  - Strong `zod` schemas for users, messages, embeds, search responses, and params.
  - `discordFetch` client with rate-limit tracking, 429 retry with backoff, and 202 “index not ready” polling.
  - `searchMessages` and `searchAllMessages` with snowflake-based partitioning, offset/maxId support, and optional progress/page callbacks; caps page size to 25.
  - Result-based error handling via `better-result` with typed errors: `DiscordApiError`, `RateLimitExhaustedError`, `IndexNotReadyError`, `ValidationError`.

<sup>Written for commit 528f771945e9c089b27d77864b70c9e44547de6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

