### PR TITLE
feat: PR-5 add CLI interactive components

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ bun run index.ts --client-id 123456789
 bun run index.ts --help
 ```
 
-> [!NOTE>
+> [!NOTE]
 > **Current Implementation Status**
-> 
+>
 > - `discord-search --help`: Shows help message ✓
 > - `discord-search --version`: Shows version number ✓
 > - Interactive mode: Not yet implemented (see `src/index.ts`)

--- a/README.md
+++ b/README.md
@@ -67,12 +67,27 @@ bun run index.ts --client-id 123456789
 bun run index.ts --help
 ```
 
+> [!NOTE>
+> **Current Implementation Status**
+> 
+> - `discord-search --help`: Shows help message ✓
+> - `discord-search --version`: Shows version number ✓
+> - Interactive mode: Not yet implemented (see `src/index.ts`)
+> - Search command: Not yet implemented (see `src/index.ts`)
+> - Preset command: Not yet implemented (see `src/index.ts`)
+> - Settings command: Not yet implemented (see `src/index.ts`)
+>
+> Refer to `src/index.ts` for the current implementation status of each command.
+
 Interactive mode
 The CLI guides you through setting up searches:
 1. Choose "New search" to start
 2. Enter your Guild ID (server ID)
 3. Optionally filter by content, author, mentions, or content types
 4. Browse results or export them
+
+> [!WARNING]
+> Interactive mode and all subcommands (search, preset, settings) are currently unimplemented. Running these will display an error message and exit with code 1. Only `--help` and `--version` are functional in this release.
 
 **Search filters**
 - Content text search

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,13 +1,36 @@
-/**
- * Placeholder test file
- *
- * This file exists to ensure CI passes during infrastructure setup.
- * Actual tests will be added in subsequent PRs.
- */
+import { expect, test } from "bun:test";
+import { parseArgs } from "@/cli/args-parse.ts";
+import type { HelpArgs } from "@/cli/args-types.ts";
 
-import { test } from "bun:test";
+test("global --help returns help command", () => {
+  const args = parseArgs(["--help"]);
+  expect(args.command).toBe("help");
+  expect((args as HelpArgs).help).toBe(true);
+});
 
-test("placeholder", () => {
-  // This is a placeholder test to make CI pass
-  // Real tests will be added as functionality is developed
+test("search --help returns help command with targetCommand search", () => {
+  const args = parseArgs(["search", "--help"]);
+  expect(args.command).toBe("help");
+  const helpArgs = args as HelpArgs;
+  expect(helpArgs.targetCommand).toBe("search");
+  expect(helpArgs.help).toBe(true);
+});
+
+test("search --help with --guild still returns help command", () => {
+  const args = parseArgs(["search", "--help", "--guild", "123"]);
+  expect(args.command).toBe("help");
+  const helpArgs = args as HelpArgs;
+  expect(helpArgs.targetCommand).toBe("search");
+  expect(helpArgs.help).toBe(true);
+});
+
+test("no subcommand without --help returns interactive command", () => {
+  const args = parseArgs([]);
+  expect(args.command).toBe("interactive");
+});
+
+test("no subcommand with --help returns help command (not interactive)", () => {
+  const args = parseArgs(["--help"]);
+  expect(args.command).toBe("help");
+  expect(args.command).not.toBe("interactive");
 });

--- a/src/cli/args-help.ts
+++ b/src/cli/args-help.ts
@@ -26,6 +26,8 @@ const GLOBAL_OPTIONS = section("GLOBAL OPTIONS", [
   opt("--help, -h", "Show this help message"),
   opt("--version, -v", "Show version number"),
   opt("--token, -t <token>", "Bot token (overrides DISCORD_BOT_TOKEN)"),
+  opt("--guild, -g <id>", "Default guild/server ID"),
+  opt("--client-id, -c <id>", "Bot client ID (for invite link)"),
 ]);
 
 const SEARCH_FILTERING = section("FILTERING", [

--- a/src/cli/args-parse.ts
+++ b/src/cli/args-parse.ts
@@ -327,14 +327,13 @@ const parseSearchCommand = (
   }
 
   if (global.version) {
-    return parseWithError<SearchArgs>(
+    return parseWithError<HelpArgs>(
       {
-        command: "search",
+        command: "help",
+        targetCommand: "search",
         help: global.help,
         version: true,
         token: global.token,
-        params: {},
-        json: false,
       },
       "search"
     );

--- a/src/cli/args-parse.ts
+++ b/src/cli/args-parse.ts
@@ -9,8 +9,8 @@ import {
   type PresetSaveArgs,
   type SearchArgs,
 } from "@/cli/args-types.ts";
-import { parseCommaSeparated } from "@/cli/utils.ts";
-import type { SearchParams } from "@/discord/schemas.ts";
+import { INTEGER_REGEX, parseCommaSeparated } from "@/cli/utils.ts";
+import { type SearchParams, SNOWFLAKE_REGEX } from "@/discord/schemas.ts";
 
 const parseWithError = <T>(data: unknown, subcommand: string): T => {
   const result = ParsedArgsSchema.safeParse(data);
@@ -106,8 +106,6 @@ const BOOLEAN_FLAGS: Record<string, keyof SearchParams> = {
   "--pinned": "pinned",
   "--mention-everyone": "mentionEveryone",
 };
-
-const INTEGER_REGEX = /^\d+$/;
 
 type SearchFlagsResult = {
   params: Omit<SearchParams, "guildId"> & { guildId?: string };
@@ -408,6 +406,13 @@ const parsePresetRunAllAction = (
     }
   }
 
+  if (all && names.length > 0) {
+    exitWithError(
+      "Cannot specify both --all and named presets",
+      "preset run-all"
+    );
+  }
+
   if (!all && names.length === 0) {
     exitWithError("You must pass --all or at least one preset name", "preset");
   }
@@ -620,6 +625,15 @@ const parseSettingsCommand = (
       return exitWithError(
         `Unknown settings key: "${key}". Valid keys: ${[...VALID_SETTINGS_KEYS].join(", ")}`,
         "settings"
+      );
+    }
+    if (
+      (key === "guild" || key === "client-id") &&
+      !SNOWFLAKE_REGEX.test(value)
+    ) {
+      return exitWithError(
+        `Invalid value for ${key}: must be a 17-20 digit snowflake ID`,
+        "settings set"
       );
     }
     checkNoLeftovers(remaining.slice(4), "settings set");

--- a/src/cli/args-parse.ts
+++ b/src/cli/args-parse.ts
@@ -313,14 +313,7 @@ const parseSearchCommand = (
   global: GlobalFlags & { guild?: string }
 ): SearchArgs | HelpArgs => {
   const guildId = global.guild;
-  if (!(global.help || guildId)) {
-    return exitWithError(
-      "Missing required --guild/-g (guildId) for search command",
-      "search"
-    );
-  }
-
-  if (global.help && !guildId) {
+  if (global.help) {
     return parseWithError<HelpArgs>(
       {
         command: "help",
@@ -329,6 +322,13 @@ const parseSearchCommand = (
         version: global.version,
         token: global.token,
       },
+      "search"
+    );
+  }
+
+  if (!guildId) {
+    return exitWithError(
+      "Missing required --guild/-g (guildId) for search command",
       "search"
     );
   }
@@ -623,6 +623,12 @@ export const parseArgs = (args: string[]): ParsedArgs => {
   const subcommand = remaining[0];
 
   if (!subcommand) {
+    if (global.help) {
+      return parseWithError<ParsedArgs>(
+        { command: "help", ...global },
+        "interactive"
+      );
+    }
     return parseWithError<ParsedArgs>(
       { command: "interactive", ...global },
       "interactive"

--- a/src/cli/args-parse.ts
+++ b/src/cli/args-parse.ts
@@ -326,6 +326,18 @@ const parseSearchCommand = (
     );
   }
 
+  if (global.version) {
+    return parseWithError<SearchArgs>(
+      {
+        command: "search",
+        help: global.help,
+        version: true,
+        token: global.token,
+      },
+      "search"
+    );
+  }
+
   if (!guildId) {
     return exitWithError(
       "Missing required --guild/-g (guildId) for search command",
@@ -478,6 +490,19 @@ const parsePresetCommand = (
     );
   }
 
+  if (global.version) {
+    return parseWithError<ParsedArgs>(
+      {
+        command: "preset",
+        action: "list",
+        help: global.help,
+        version: true,
+        token: global.token,
+      },
+      "preset"
+    );
+  }
+
   const action = remaining[1];
 
   if (action === "list") {
@@ -545,6 +570,19 @@ const parseSettingsCommand = (
         targetCommand: "settings",
         help: true,
         version: global.version,
+        token: global.token,
+      },
+      "settings"
+    );
+  }
+
+  if (global.version) {
+    return parseWithError<ParsedArgs>(
+      {
+        command: "settings",
+        action: "show",
+        help: global.help,
+        version: true,
         token: global.token,
       },
       "settings"

--- a/src/cli/args-parse.ts
+++ b/src/cli/args-parse.ts
@@ -333,6 +333,8 @@ const parseSearchCommand = (
         help: global.help,
         version: true,
         token: global.token,
+        params: {},
+        json: false,
       },
       "search"
     );

--- a/src/cli/browser.ts
+++ b/src/cli/browser.ts
@@ -165,22 +165,22 @@ export const browseMessages = (messages: Message[]): Promise<void> => {
       // No-op initially, replaced by actual cleanup after first render
     };
 
-    const render = () => {
+    const render = (): boolean => {
       const msg = messages[state.index];
       if (!msg) {
-        return;
+        return true;
       }
       try {
         renderMessageView(msg, state.index, messages.length, state.viewMode);
+        return true;
       } catch (err) {
         handleRenderError(err, reject, cleanup);
+        return false;
       }
     };
 
-    try {
-      render();
-    } catch (err) {
-      reject(err);
+    const renderSucceeded = render();
+    if (!renderSucceeded) {
       return;
     }
 
@@ -191,12 +191,7 @@ export const browseMessages = (messages: Message[]): Promise<void> => {
       }
 
       navigate(key, state, messages.length);
-
-      try {
-        render();
-      } catch (err) {
-        handleRenderError(err, reject, cleanup);
-      }
+      render();
     });
   });
 };

--- a/src/cli/browser.ts
+++ b/src/cli/browser.ts
@@ -106,8 +106,12 @@ const handleRenderError = (
   reject: (reason?: unknown) => void,
   cleanup: () => void
 ): void => {
+  try {
+    cleanup();
+  } catch {
+    // Swallow cleanup errors to preserve original error
+  }
   reject(err);
-  cleanup();
 };
 
 const handleQuit = (
@@ -157,6 +161,10 @@ export const browseMessages = (messages: Message[]): Promise<void> => {
 
     const state = { index: 0, viewMode: "preview" as const };
 
+    let cleanup: () => void = () => {
+      // No-op initially, replaced by actual cleanup after first render
+    };
+
     const render = () => {
       const msg = messages[state.index];
       if (!msg) {
@@ -176,7 +184,7 @@ export const browseMessages = (messages: Message[]): Promise<void> => {
       return;
     }
 
-    const cleanup = createKeyListener((key) => {
+    cleanup = createKeyListener((key) => {
       if (key === "q" || key === "\x1b") {
         handleQuit(cleanup, resolve, reject);
         return;

--- a/src/cli/browser.ts
+++ b/src/cli/browser.ts
@@ -1,5 +1,6 @@
 import {
   ANSI_CLEAR_SCREEN,
+  ANSI_CURSOR_HOME,
   ANSI_CYAN,
   ANSI_DIM,
   ANSI_RESET,
@@ -7,6 +8,18 @@ import {
 } from "@/cli/ansi.ts";
 import { createKeyListener } from "@/cli/keys.ts";
 import type { Message } from "@/discord/schemas.ts";
+
+const formatTimestamp = (timestamp: string): string => {
+  const date = new Date(timestamp);
+  return date.toLocaleString([], {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+};
 
 const formatMessagePreview = (msg: Message): string => {
   const author = msg.author.bot
@@ -26,7 +39,16 @@ const formatMessagePreview = (msg: Message): string => {
     msg.content.length > 100
       ? `${msg.content.slice(0, 100)}...`
       : msg.content || "(no text content)";
-  return `${ANSI_DIM}${msg.timestamp}${ANSI_RESET} ${ANSI_CYAN}${author}${ANSI_RESET}: ${content}${suffix}`;
+  return `${ANSI_DIM}${formatTimestamp(msg.timestamp)}${ANSI_RESET} ${ANSI_CYAN}${author}${ANSI_RESET}: ${content}${suffix}`;
+};
+
+const truncate = (text: string, maxLen: number): string =>
+  text.length > maxLen ? `${text.slice(0, maxLen)}...` : text;
+
+const renderField = (field: { name: string; value: string }): void => {
+  const name = truncate(field.name, 40);
+  const value = truncate(field.value, 100);
+  process.stdout.write(`  ${ANSI_CYAN}${name}:${ANSI_RESET} ${value}\n`);
 };
 
 const renderEmbedPreview = (msg: Message): void => {
@@ -36,20 +58,16 @@ const renderEmbedPreview = (msg: Message): void => {
 
   for (const embed of msg.embeds) {
     if (embed.title) {
-      process.stdout.write(`  Embed: ${embed.title}\n`);
+      const title = truncate(embed.title, 80);
+      process.stdout.write(`  Embed: ${title}\n`);
     }
     if (embed.description) {
-      const desc =
-        embed.description.length > 200
-          ? `${embed.description.slice(0, 200)}...`
-          : embed.description;
+      const desc = truncate(embed.description, 200);
       process.stdout.write(`  ${ANSI_DIM}${desc}${ANSI_RESET}\n`);
     }
     if (embed.fields) {
       for (const field of embed.fields) {
-        process.stdout.write(
-          `  ${ANSI_CYAN}${field.name}:${ANSI_RESET} ${field.value}\n`
-        );
+        renderField(field);
       }
     }
     process.stdout.write("\n");
@@ -62,7 +80,7 @@ const renderMessageView = (
   total: number,
   viewMode: "preview" | "json"
 ): void => {
-  process.stdout.write(ANSI_CLEAR_SCREEN);
+  process.stdout.write(ANSI_CLEAR_SCREEN + ANSI_CURSOR_HOME);
   process.stdout.write(
     `${ANSI_YELLOW}Message ${index + 1} of ${total}${ANSI_RESET}\n\n`
   );
@@ -75,48 +93,102 @@ const renderMessageView = (
   }
 
   process.stdout.write(
-    `\n${ANSI_DIM}[j/↓] next  [k/↑] prev  [v] toggle JSON  [q] back${ANSI_RESET}\n`
+    `\n${ANSI_DIM}[j/↓] next  [k/↑] prev  [v] toggle JSON  [q/Esc] back${ANSI_RESET}\n`
   );
 };
 
+const safeWrite = (text: string): void => {
+  process.stdout.write(text);
+};
+
+const handleRenderError = (
+  err: unknown,
+  reject: (reason?: unknown) => void,
+  cleanup: () => void
+): void => {
+  reject(err);
+  cleanup();
+};
+
+const handleQuit = (
+  cleanup: () => void,
+  resolve: () => void,
+  reject: (reason?: unknown) => void
+): void => {
+  try {
+    cleanup();
+    safeWrite(ANSI_CLEAR_SCREEN + ANSI_CURSOR_HOME);
+    resolve();
+  } catch (err) {
+    reject(err);
+  }
+};
+
+const navigate = (
+  key: string,
+  state: { index: number; viewMode: "preview" | "json" },
+  total: number
+): void => {
+  if (key === "j" || key === "\x1b[B") {
+    state.index = Math.min(state.index + 1, total - 1);
+  } else if (key === "k" || key === "\x1b[A") {
+    state.index = Math.max(state.index - 1, 0);
+  } else if (key === "v") {
+    state.viewMode = state.viewMode === "preview" ? "json" : "preview";
+  }
+};
+
 export const browseMessages = (messages: Message[]): Promise<void> => {
-  return new Promise((resolve) => {
+  if (!process.stdin.isTTY) {
+    safeWrite("Interactive browsing requires a TTY terminal.\n");
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
     if (messages.length === 0) {
-      process.stdout.write(`${ANSI_DIM}No messages to browse.${ANSI_RESET}\n`);
-      resolve();
+      try {
+        safeWrite(`${ANSI_DIM}No messages to browse.${ANSI_RESET}\n`);
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
       return;
     }
 
-    let index = 0;
-    let viewMode: "preview" | "json" = "preview";
+    const state = { index: 0, viewMode: "preview" as const };
 
     const render = () => {
-      const msg = messages[index];
+      const msg = messages[state.index];
       if (!msg) {
         return;
       }
-      renderMessageView(msg, index, messages.length, viewMode);
+      try {
+        renderMessageView(msg, state.index, messages.length, state.viewMode);
+      } catch (err) {
+        handleRenderError(err, reject, cleanup);
+      }
     };
 
-    render();
+    try {
+      render();
+    } catch (err) {
+      reject(err);
+      return;
+    }
 
     const cleanup = createKeyListener((key) => {
       if (key === "q" || key === "\x1b") {
-        cleanup();
-        process.stdout.write(ANSI_CLEAR_SCREEN);
-        resolve();
+        handleQuit(cleanup, resolve, reject);
         return;
       }
 
-      if (key === "j" || key === "\x1b[B") {
-        index = Math.min(index + 1, messages.length - 1);
-      } else if (key === "k" || key === "\x1b[A") {
-        index = Math.max(index - 1, 0);
-      } else if (key === "v") {
-        viewMode = viewMode === "preview" ? "json" : "preview";
-      }
+      navigate(key, state, messages.length);
 
-      render();
+      try {
+        render();
+      } catch (err) {
+        handleRenderError(err, reject, cleanup);
+      }
     });
   });
 };

--- a/src/cli/browser.ts
+++ b/src/cli/browser.ts
@@ -82,6 +82,7 @@ const renderMessageView = (
 export const browseMessages = (messages: Message[]): Promise<void> => {
   return new Promise((resolve) => {
     if (messages.length === 0) {
+      process.stdout.write(`${ANSI_DIM}No messages to browse.${ANSI_RESET}\n`);
       resolve();
       return;
     }

--- a/src/cli/browser.ts
+++ b/src/cli/browser.ts
@@ -1,0 +1,121 @@
+import {
+  ANSI_CLEAR_SCREEN,
+  ANSI_CYAN,
+  ANSI_DIM,
+  ANSI_RESET,
+  ANSI_YELLOW,
+} from "@/cli/ansi.ts";
+import { createKeyListener } from "@/cli/keys.ts";
+import type { Message } from "@/discord/schemas.ts";
+
+const formatMessagePreview = (msg: Message): string => {
+  const author = msg.author.bot
+    ? `${msg.author.username} [BOT]`
+    : msg.author.username;
+  const embedCount = msg.embeds?.length ?? 0;
+  const attachCount = msg.attachments?.length ?? 0;
+  const extras: string[] = [];
+  if (embedCount > 0) {
+    extras.push(`${embedCount} embed(s)`);
+  }
+  if (attachCount > 0) {
+    extras.push(`${attachCount} attachment(s)`);
+  }
+  const suffix = extras.length > 0 ? ` [${extras.join(", ")}]` : "";
+  const content =
+    msg.content.length > 100
+      ? `${msg.content.slice(0, 100)}...`
+      : msg.content || "(no text content)";
+  return `${ANSI_DIM}${msg.timestamp}${ANSI_RESET} ${ANSI_CYAN}${author}${ANSI_RESET}: ${content}${suffix}`;
+};
+
+const renderEmbedPreview = (msg: Message): void => {
+  if (!msg.embeds || msg.embeds.length === 0) {
+    return;
+  }
+
+  for (const embed of msg.embeds) {
+    if (embed.title) {
+      process.stdout.write(`  Embed: ${embed.title}\n`);
+    }
+    if (embed.description) {
+      const desc =
+        embed.description.length > 200
+          ? `${embed.description.slice(0, 200)}...`
+          : embed.description;
+      process.stdout.write(`  ${ANSI_DIM}${desc}${ANSI_RESET}\n`);
+    }
+    if (embed.fields) {
+      for (const field of embed.fields) {
+        process.stdout.write(
+          `  ${ANSI_CYAN}${field.name}:${ANSI_RESET} ${field.value}\n`
+        );
+      }
+    }
+    process.stdout.write("\n");
+  }
+};
+
+const renderMessageView = (
+  msg: Message,
+  index: number,
+  total: number,
+  viewMode: "preview" | "json"
+): void => {
+  process.stdout.write(ANSI_CLEAR_SCREEN);
+  process.stdout.write(
+    `${ANSI_YELLOW}Message ${index + 1} of ${total}${ANSI_RESET}\n\n`
+  );
+
+  if (viewMode === "json") {
+    process.stdout.write(`${JSON.stringify(msg, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatMessagePreview(msg)}\n\n`);
+    renderEmbedPreview(msg);
+  }
+
+  process.stdout.write(
+    `\n${ANSI_DIM}[j/↓] next  [k/↑] prev  [v] toggle JSON  [q] back${ANSI_RESET}\n`
+  );
+};
+
+export const browseMessages = (messages: Message[]): Promise<void> => {
+  return new Promise((resolve) => {
+    if (messages.length === 0) {
+      resolve();
+      return;
+    }
+
+    let index = 0;
+    let viewMode: "preview" | "json" = "preview";
+
+    const render = () => {
+      const msg = messages[index];
+      if (!msg) {
+        return;
+      }
+      renderMessageView(msg, index, messages.length, viewMode);
+    };
+
+    render();
+
+    const cleanup = createKeyListener((key) => {
+      if (key === "q" || key === "\x1b") {
+        cleanup();
+        process.stdout.write(ANSI_CLEAR_SCREEN);
+        resolve();
+        return;
+      }
+
+      if (key === "j" || key === "\x1b[B") {
+        index = Math.min(index + 1, messages.length - 1);
+      } else if (key === "k" || key === "\x1b[A") {
+        index = Math.max(index - 1, 0);
+      } else if (key === "v") {
+        viewMode = viewMode === "preview" ? "json" : "preview";
+      }
+
+      render();
+    });
+  });
+};

--- a/src/cli/browser.ts
+++ b/src/cli/browser.ts
@@ -97,7 +97,7 @@ const renderMessageView = (
   );
 };
 
-const safeWrite = (text: string): void => {
+const write = (text: string): void => {
   process.stdout.write(text);
 };
 
@@ -121,7 +121,7 @@ const handleQuit = (
 ): void => {
   try {
     cleanup();
-    safeWrite(ANSI_CLEAR_SCREEN + ANSI_CURSOR_HOME);
+    write(ANSI_CLEAR_SCREEN + ANSI_CURSOR_HOME);
     resolve();
   } catch (err) {
     reject(err);
@@ -144,14 +144,14 @@ const navigate = (
 
 export const browseMessages = (messages: Message[]): Promise<void> => {
   if (!process.stdin.isTTY) {
-    safeWrite("Interactive browsing requires a TTY terminal.\n");
+    write("Interactive browsing requires a TTY terminal.\n");
     return Promise.resolve();
   }
 
   return new Promise((resolve, reject) => {
     if (messages.length === 0) {
       try {
-        safeWrite(`${ANSI_DIM}No messages to browse.${ANSI_RESET}\n`);
+        write(`${ANSI_DIM}No messages to browse.${ANSI_RESET}\n`);
         resolve();
       } catch (err) {
         reject(err);

--- a/src/cli/keys.ts
+++ b/src/cli/keys.ts
@@ -31,7 +31,7 @@ export const createKeyListener = (onKey: KeyHandler): (() => void) => {
     if (!wasRaw) {
       process.stdin.setRawMode(false);
     }
-    if (previousEncoding) {
+    if (previousEncoding !== null) {
       process.stdin.setEncoding(previousEncoding);
     }
     process.stdin.pause();

--- a/src/cli/keys.ts
+++ b/src/cli/keys.ts
@@ -31,6 +31,8 @@ export const createKeyListener = (onKey: KeyHandler): (() => void) => {
     if (!wasRaw) {
       process.stdin.setRawMode(false);
     }
+    // Note: Node.js does not support un-setting encoding back to null (raw Buffer mode).
+    // If stdin had no encoding before, it remains in "utf8" after cleanup.
     if (previousEncoding !== null) {
       process.stdin.setEncoding(previousEncoding);
     }

--- a/src/cli/keys.ts
+++ b/src/cli/keys.ts
@@ -8,13 +8,17 @@ export const createKeyListener = (onKey: KeyHandler): (() => void) => {
   }
 
   const wasRaw = process.stdin.isRaw;
+  const previousEncoding = process.stdin.readableEncoding;
   process.stdin.setRawMode(true);
   process.stdin.resume();
   process.stdin.setEncoding("utf8");
 
+  let cleanup: () => void;
+
   const handler = (data: string) => {
     // Ctrl+C — exit
     if (data === "\x03") {
+      cleanup();
       process.exit(0);
     }
     onKey(data);
@@ -22,11 +26,16 @@ export const createKeyListener = (onKey: KeyHandler): (() => void) => {
 
   process.stdin.on("data", handler);
 
-  return () => {
+  cleanup = () => {
     process.stdin.removeListener("data", handler);
     if (!wasRaw) {
       process.stdin.setRawMode(false);
     }
+    if (previousEncoding) {
+      process.stdin.setEncoding(previousEncoding);
+    }
     process.stdin.pause();
   };
+
+  return cleanup;
 };

--- a/src/cli/keys.ts
+++ b/src/cli/keys.ts
@@ -1,0 +1,32 @@
+type KeyHandler = (key: string) => void;
+
+export const createKeyListener = (onKey: KeyHandler): (() => void) => {
+  if (!process.stdin.isTTY) {
+    return () => {
+      // no-op: not a TTY
+    };
+  }
+
+  const wasRaw = process.stdin.isRaw;
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.setEncoding("utf8");
+
+  const handler = (data: string) => {
+    // Ctrl+C — exit
+    if (data === "\x03") {
+      process.exit(0);
+    }
+    onKey(data);
+  };
+
+  process.stdin.on("data", handler);
+
+  return () => {
+    process.stdin.removeListener("data", handler);
+    if (!wasRaw) {
+      process.stdin.setRawMode(false);
+    }
+    process.stdin.pause();
+  };
+};

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -7,6 +7,7 @@ import {
   select,
   text,
 } from "@clack/prompts";
+import { parseCommaSeparated } from "@/cli/utils.ts";
 import type { SearchParams } from "@/discord/schemas.ts";
 
 export const handleCancel = (value: unknown): void => {
@@ -14,17 +15,6 @@ export const handleCancel = (value: unknown): void => {
     cancel("Search cancelled.");
     process.exit(0);
   }
-};
-
-export const parseCommaSeparated = (value: string): string[] | undefined => {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  return trimmed
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
 };
 
 export const promptForToken = async (): Promise<string> => {
@@ -68,18 +58,22 @@ export const promptForSearchParams = async (
   });
   handleCancel(filterByAuthorType);
 
-  let authorType: string | undefined;
+  let authorType: string[] | undefined;
   if (filterByAuthorType) {
-    const selected = await select({
+    const selected = await multiselect({
       message: "Author type:",
       options: [
-        { value: "user", label: "Users only" },
-        { value: "bot", label: "Bots only" },
-        { value: "webhook", label: "Webhooks only" },
+        { value: "user", label: "Users" },
+        { value: "bot", label: "Bots" },
+        { value: "webhook", label: "Webhooks" },
       ],
+      required: false,
     });
     handleCancel(selected);
-    authorType = selected as string;
+    const selectedArray = selected as string[] | undefined;
+    if (selectedArray && selectedArray.length > 0) {
+      authorType = selectedArray as ("user" | "bot" | "webhook")[];
+    }
   }
 
   const mentionIds = await text({
@@ -170,21 +164,21 @@ export const promptForSearchParams = async (
   }
 
   const authorIdList = parseCommaSeparated(authorIds as string);
-  if (authorIdList) {
+  if (authorIdList && authorIdList.length > 0) {
     params.authorId = authorIdList;
   }
 
   if (authorType) {
-    params.authorType = [authorType as "user" | "bot" | "webhook"];
+    params.authorType = authorType as ("user" | "bot" | "webhook")[];
   }
 
   const mentionList = parseCommaSeparated(mentionIds as string);
-  if (mentionList) {
+  if (mentionList && mentionList.length > 0) {
     params.mentions = mentionList;
   }
 
   const channelList = parseCommaSeparated(channelIds as string);
-  if (channelList) {
+  if (channelList && channelList.length > 0) {
     params.channelId = channelList;
   }
 

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -7,11 +7,8 @@ import {
   select,
   text,
 } from "@clack/prompts";
-import { parseCommaSeparated } from "@/cli/utils.ts";
-import type { SearchParams } from "@/discord/schemas.ts";
-
-const INTEGER_REGEX = /^\d+$/;
-const SNOWFLAKE_REGEX = /^\d{17,20}$/;
+import { INTEGER_REGEX, parseCommaSeparated } from "@/cli/utils.ts";
+import { type SearchParams, SNOWFLAKE_REGEX } from "@/discord/schemas.ts";
 
 export function handleCancel<T>(value: T | symbol): asserts value is T {
   if (isCancel(value)) {

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -10,6 +10,8 @@ import {
 import { parseCommaSeparated } from "@/cli/utils.ts";
 import type { SearchParams } from "@/discord/schemas.ts";
 
+const INTEGER_REGEX = /^\d+$/;
+
 export const handleCancel = (value: unknown): void => {
   if (isCancel(value)) {
     cancel("Search cancelled.");
@@ -133,7 +135,8 @@ export const promptForSearchParams = async (
     message: "Max messages to fetch (leave empty for all):",
     placeholder: "e.g. 100",
     validate: (v) => {
-      if (v?.trim() && Number.isNaN(Number.parseInt(v.trim(), 10))) {
+      const trimmed = v?.trim();
+      if (trimmed && !INTEGER_REGEX.test(trimmed)) {
         return "Must be a number";
       }
     },
@@ -144,7 +147,8 @@ export const promptForSearchParams = async (
     message: "Offset / skip first N results (leave empty for 0):",
     placeholder: "e.g. 50",
     validate: (v) => {
-      if (v?.trim() && Number.isNaN(Number.parseInt(v.trim(), 10))) {
+      const trimmed = v?.trim();
+      if (trimmed && !INTEGER_REGEX.test(trimmed)) {
         return "Must be a number";
       }
     },

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -11,13 +11,14 @@ import { parseCommaSeparated } from "@/cli/utils.ts";
 import type { SearchParams } from "@/discord/schemas.ts";
 
 const INTEGER_REGEX = /^\d+$/;
+const SNOWFLAKE_REGEX = /^\d{17,20}$/;
 
-export const handleCancel = (value: unknown): void => {
+export function handleCancel<T>(value: T | symbol): asserts value is T {
   if (isCancel(value)) {
     cancel("Search cancelled.");
     process.exit(0);
   }
-};
+}
 
 export const promptForToken = async (): Promise<string> => {
   const token = await password({
@@ -35,8 +36,12 @@ export const promptForSearchParams = async (
     message: "Guild (Server) ID:",
     initialValue: defaultGuildId,
     validate: (v) => {
-      if (!v?.trim()) {
+      const trimmed = v?.trim();
+      if (!trimmed) {
         return "Guild ID is required";
+      }
+      if (!SNOWFLAKE_REGEX.test(trimmed)) {
+        return "Guild ID must be a 17–20 digit Discord snowflake";
       }
     },
   });

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -1,0 +1,198 @@
+import {
+  cancel,
+  confirm,
+  isCancel,
+  multiselect,
+  password,
+  select,
+  text,
+} from "@clack/prompts";
+import type { SearchParams } from "@/discord/schemas.ts";
+
+export const handleCancel = (value: unknown): value is symbol => {
+  if (isCancel(value)) {
+    cancel("Search cancelled.");
+    process.exit(0);
+  }
+  return false;
+};
+
+export const parseCommaSeparated = (value: string): string[] | undefined => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+};
+
+export const promptForToken = async (): Promise<string> => {
+  const token = await password({
+    message: "Enter your Discord Bot Token:",
+  });
+  handleCancel(token);
+  return token as string;
+};
+
+export const promptForSearchParams = async (
+  defaultGuildId?: string
+): Promise<SearchParams> => {
+  const guildId = await text({
+    message: "Guild (Server) ID:",
+    initialValue: defaultGuildId,
+    validate: (v) => {
+      if (!v?.trim()) {
+        return "Guild ID is required";
+      }
+    },
+  });
+  handleCancel(guildId);
+
+  const content = await text({
+    message: "Content filter (leave empty for all):",
+    placeholder: "search text...",
+  });
+  handleCancel(content);
+
+  const authorIds = await text({
+    message: "Author IDs (comma-separated, leave empty for all):",
+    placeholder: "123456789,987654321",
+  });
+  handleCancel(authorIds);
+
+  const authorType = await select({
+    message: "Author type filter:",
+    options: [
+      { value: "none", label: "Any (no filter)" },
+      { value: "user", label: "Users only" },
+      { value: "bot", label: "Bots only" },
+      { value: "webhook", label: "Webhooks only" },
+    ],
+  });
+  handleCancel(authorType);
+
+  const mentionIds = await text({
+    message: "Mentions user IDs (comma-separated, leave empty to skip):",
+    placeholder: "123456789",
+  });
+  handleCancel(mentionIds);
+
+  const channelIds = await text({
+    message: "Channel IDs (comma-separated, leave empty for all):",
+    placeholder: "123456789,987654321",
+  });
+  handleCancel(channelIds);
+
+  const hasFilter = await multiselect({
+    message: "Has content type (select none to skip):",
+    options: [
+      { value: "embed", label: "Embed" },
+      { value: "image", label: "Image" },
+      { value: "video", label: "Video" },
+      { value: "file", label: "File" },
+      { value: "link", label: "Link" },
+      { value: "sticker", label: "Sticker" },
+      { value: "sound", label: "Sound" },
+      { value: "poll", label: "Poll" },
+      { value: "snapshot", label: "Snapshot" },
+    ],
+    required: false,
+  });
+  handleCancel(hasFilter);
+
+  const sortBy = await select({
+    message: "Sort by:",
+    options: [
+      { value: "timestamp", label: "Timestamp" },
+      { value: "relevance", label: "Relevance" },
+    ],
+  });
+  handleCancel(sortBy);
+
+  const sortOrder = await select({
+    message: "Sort order:",
+    options: [
+      { value: "desc", label: "Newest first" },
+      { value: "asc", label: "Oldest first" },
+    ],
+  });
+  handleCancel(sortOrder);
+
+  const includeNsfw = await confirm({
+    message: "Include NSFW channels?",
+    initialValue: false,
+  });
+  handleCancel(includeNsfw);
+
+  const limitInput = await text({
+    message: "Max messages to fetch (leave empty for all):",
+    placeholder: "e.g. 100",
+    validate: (v) => {
+      if (v?.trim() && Number.isNaN(Number.parseInt(v.trim(), 10))) {
+        return "Must be a number";
+      }
+    },
+  });
+  handleCancel(limitInput);
+
+  const offsetInput = await text({
+    message: "Offset / skip first N results (leave empty for 0):",
+    placeholder: "e.g. 50",
+    validate: (v) => {
+      if (v?.trim() && Number.isNaN(Number.parseInt(v.trim(), 10))) {
+        return "Must be a number";
+      }
+    },
+  });
+  handleCancel(offsetInput);
+
+  const params: SearchParams = {
+    guildId: (guildId as string).trim(),
+    sortBy: sortBy as "timestamp" | "relevance",
+    sortOrder: sortOrder as "asc" | "desc",
+    includeNsfw: includeNsfw as boolean,
+  };
+
+  const contentStr = (content as string).trim();
+  if (contentStr) {
+    params.content = contentStr;
+  }
+
+  const authorIdList = parseCommaSeparated(authorIds as string);
+  if (authorIdList) {
+    params.authorId = authorIdList;
+  }
+
+  if (authorType !== "none") {
+    params.authorType = [authorType as "user" | "bot" | "webhook"];
+  }
+
+  const mentionList = parseCommaSeparated(mentionIds as string);
+  if (mentionList) {
+    params.mentions = mentionList;
+  }
+
+  const channelList = parseCommaSeparated(channelIds as string);
+  if (channelList) {
+    params.channelId = channelList;
+  }
+
+  const hasFilterArr = hasFilter as string[];
+  if (hasFilterArr.length > 0) {
+    params.has = hasFilterArr as SearchParams["has"];
+  }
+
+  const limitStr = (limitInput as string).trim();
+  if (limitStr) {
+    params.limit = Number.parseInt(limitStr, 10);
+  }
+
+  const offsetStr = (offsetInput as string).trim();
+  if (offsetStr) {
+    params.offset = Number.parseInt(offsetStr, 10);
+  }
+
+  return params;
+};

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -9,12 +9,11 @@ import {
 } from "@clack/prompts";
 import type { SearchParams } from "@/discord/schemas.ts";
 
-export const handleCancel = (value: unknown): value is symbol => {
+export const handleCancel = (value: unknown): void => {
   if (isCancel(value)) {
     cancel("Search cancelled.");
     process.exit(0);
   }
-  return false;
 };
 
 export const parseCommaSeparated = (value: string): string[] | undefined => {
@@ -31,6 +30,7 @@ export const parseCommaSeparated = (value: string): string[] | undefined => {
 export const promptForToken = async (): Promise<string> => {
   const token = await password({
     message: "Enter your Discord Bot Token:",
+    validate: (v) => (v?.trim() ? undefined : "Token cannot be empty"),
   });
   handleCancel(token);
   return token as string;
@@ -62,16 +62,25 @@ export const promptForSearchParams = async (
   });
   handleCancel(authorIds);
 
-  const authorType = await select({
-    message: "Author type filter:",
-    options: [
-      { value: "none", label: "Any (no filter)" },
-      { value: "user", label: "Users only" },
-      { value: "bot", label: "Bots only" },
-      { value: "webhook", label: "Webhooks only" },
-    ],
+  const filterByAuthorType = await confirm({
+    message: "Filter by author type?",
+    initialValue: false,
   });
-  handleCancel(authorType);
+  handleCancel(filterByAuthorType);
+
+  let authorType: string | undefined;
+  if (filterByAuthorType) {
+    const selected = await select({
+      message: "Author type:",
+      options: [
+        { value: "user", label: "Users only" },
+        { value: "bot", label: "Bots only" },
+        { value: "webhook", label: "Webhooks only" },
+      ],
+    });
+    handleCancel(selected);
+    authorType = selected as string;
+  }
 
   const mentionIds = await text({
     message: "Mentions user IDs (comma-separated, leave empty to skip):",
@@ -165,7 +174,7 @@ export const promptForSearchParams = async (
     params.authorId = authorIdList;
   }
 
-  if (authorType !== "none") {
+  if (authorType) {
     params.authorType = [authorType as "user" | "bot" | "webhook"];
   }
 

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,3 +1,5 @@
+export const INTEGER_REGEX = /^\d+$/;
+
 export const parseCommaSeparated = (input: string): string[] | undefined => {
   const trimmed = input.trim();
   if (!trimmed) {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,6 +1,10 @@
-/** Split a comma-separated string into trimmed, non-empty tokens. */
-export const parseCommaSeparated = (input: string): string[] =>
-  input
+export const parseCommaSeparated = (input: string): string[] | undefined => {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
+};

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -65,17 +65,19 @@ const updateRateLimitState = (
   headers: Headers,
   bucketKey: BucketKey,
   computedKey: BucketKey
-): void => {
+): BucketKey => {
   const state = getBucketState(bucketKey);
   const remaining = headers.get("X-RateLimit-Remaining");
   const resetAfter = headers.get("X-RateLimit-Reset-After");
   const bucket = headers.get("X-RateLimit-Bucket");
 
+  let activeBucketKey = bucketKey;
   if (bucket !== null && `discord:${bucket}` !== bucketKey) {
     const discordBucketKey = `discord:${bucket}`;
     rateLimitBuckets.delete(bucketKey);
     rateLimitBuckets.set(discordBucketKey, state);
     bucketKeyMap.set(computedKey, discordBucketKey);
+    activeBucketKey = discordBucketKey;
   }
 
   if (remaining !== null) {
@@ -85,6 +87,7 @@ const updateRateLimitState = (
     state.resetAfterMs = Number.parseFloat(resetAfter) * 1000;
   }
   state.lastRequestTime = Date.now();
+  return activeBucketKey;
 };
 
 const waitForRateLimit = async (bucketKey: BucketKey): Promise<void> => {
@@ -221,11 +224,12 @@ const handle202 = async <T>(
   schema: z.ZodType<T>,
   maxRetries: number,
   maxRetries429: number,
-  bucketKey: BucketKey,
+  initialBucketKey: BucketKey,
   computedKey: BucketKey,
   rateLimitCounter: RetryCounter
 ): Promise<Result<T, DiscordFetchError>> => {
   let retryAfter = await parseRetryAfterFrom202(response);
+  let bucketKey = initialBucketKey;
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     await sleep(retryAfter * 1000);
@@ -237,7 +241,11 @@ const handle202 = async <T>(
     }
 
     const retryResponse = retryResult.value;
-    updateRateLimitState(retryResponse.headers, bucketKey, computedKey);
+    bucketKey = updateRateLimitState(
+      retryResponse.headers,
+      bucketKey,
+      computedKey
+    );
 
     if (retryResponse.status === 429) {
       const rateLimitResult = await handle429(
@@ -331,7 +339,7 @@ export const discordFetch = async <T>(
 ): Promise<Result<T, DiscordFetchError>> => {
   const url = `${DISCORD_API_BASE}${path}`;
   const computedKey = computeBucketKey(path, token);
-  const bucketKey = bucketKeyMap.get(computedKey) ?? computedKey;
+  let bucketKey = bucketKeyMap.get(computedKey) ?? computedKey;
   const rateLimitCounter: RetryCounter = { value: 0 };
 
   for (; rateLimitCounter.value <= maxRetries429; rateLimitCounter.value++) {
@@ -343,7 +351,7 @@ export const discordFetch = async <T>(
     }
 
     const response = fetchResult.value;
-    updateRateLimitState(response.headers, bucketKey, computedKey);
+    bucketKey = updateRateLimitState(response.headers, bucketKey, computedKey);
 
     if (response.status === 429) {
       const result = await handle429(

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -25,6 +25,12 @@ type RateLimitState = {
 
 type BucketKey = string;
 
+/**
+ * Module-level rate limit state shared across all calls to discordFetch.
+ * Keyed per bucket (endpoint path + token hash), so different endpoints
+ * maintain independent rate limit tracking. Assumes sequential usage
+ * per bucket — concurrent requests to the same bucket may race.
+ */
 const rateLimitBuckets = new Map<BucketKey, RateLimitState>();
 const bucketKeyMap = new Map<BucketKey, BucketKey>();
 

--- a/src/discord/schemas.ts
+++ b/src/discord/schemas.ts
@@ -205,7 +205,7 @@ export const SearchParamsSchema = z.object({
   sortBy: z.enum(["timestamp", "relevance"]).optional(),
   sortOrder: z.enum(["asc", "desc"]).optional(),
   offset: z.number().int().min(0).max(MAX_OFFSET).optional(),
-  limit: z.number().int().min(1).max(MAX_PAGE_SIZE).optional(),
+  limit: z.number().int().min(1).optional(),
 });
 
 // Inferred types

--- a/src/discord/schemas.ts
+++ b/src/discord/schemas.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const MAX_OFFSET = 9975;
 export const MAX_PAGE_SIZE = 25;
 
-const SNOWFLAKE_REGEX = /^\d{17,20}$/;
+export const SNOWFLAKE_REGEX = /^\d{17,20}$/;
 
 const snowflakeSchema = z.string().regex(SNOWFLAKE_REGEX, {
   message: "Invalid Discord ID: must be a 17-20 digit numeric snowflake",

--- a/src/discord/schemas.ts
+++ b/src/discord/schemas.ts
@@ -5,12 +5,9 @@ export const MAX_PAGE_SIZE = 25;
 
 const SNOWFLAKE_REGEX = /^\d{17,20}$/;
 
-const snowflakeSchema = z
-  .string()
-  .regex(SNOWFLAKE_REGEX, {
-    message: "Invalid Discord ID: must be a 17-20 digit numeric snowflake",
-  })
-  .max(20, { message: "Discord ID exceeds maximum length of 20 characters" });
+const snowflakeSchema = z.string().regex(SNOWFLAKE_REGEX, {
+  message: "Invalid Discord ID: must be a 17-20 digit numeric snowflake",
+});
 
 const snowflakeArraySchema = z.array(snowflakeSchema);
 

--- a/src/discord/search.ts
+++ b/src/discord/search.ts
@@ -197,7 +197,9 @@ const fetchPage = async (
     );
   }
 
-  state.allMessages.push(...pageMessages);
+  for (const msg of pageMessages) {
+    state.allMessages.push(msg);
+  }
   onPage?.(pageMessages);
   onProgress?.({
     fetched: state.allMessages.length,

--- a/src/discord/search.ts
+++ b/src/discord/search.ts
@@ -165,11 +165,9 @@ const fetchPage = async (
     ? Math.min(params.limit, MAX_PAGE_SIZE)
     : MAX_PAGE_SIZE;
 
-  if (state.totalResults === 0) {
-    state.totalResults = maxMessages
-      ? Math.min(data.total_results, maxMessages)
-      : data.total_results;
-  }
+  state.totalResults = maxMessages
+    ? Math.min(data.total_results, maxMessages)
+    : data.total_results;
 
   let pageMessages = data.messages
     .map((group) => group[0])

--- a/src/discord/search.ts
+++ b/src/discord/search.ts
@@ -197,7 +197,7 @@ const fetchPage = async (
     );
   }
 
-  Array.prototype.push.apply(state.allMessages, pageMessages);
+  state.allMessages.push(...pageMessages);
   onPage?.(pageMessages);
   onProgress?.({
     fetched: state.allMessages.length,

--- a/src/discord/search.ts
+++ b/src/discord/search.ts
@@ -161,9 +161,7 @@ const fetchPage = async (
   }
 
   const data = result.value;
-  const pageSize = params.limit
-    ? Math.min(params.limit, MAX_PAGE_SIZE)
-    : MAX_PAGE_SIZE;
+  const pageSize = MAX_PAGE_SIZE; // Always use MAX_PAGE_SIZE for API calls
 
   // Only capture totalResults from the first (unfiltered) response.
   // Subsequent partitions with max_id return a smaller total_results

--- a/src/discord/search.ts
+++ b/src/discord/search.ts
@@ -161,7 +161,9 @@ const fetchPage = async (
   }
 
   const data = result.value;
-  const pageSize = MAX_PAGE_SIZE; // Always use MAX_PAGE_SIZE for API calls
+  const pageSize = params.limit
+    ? Math.min(params.limit, MAX_PAGE_SIZE)
+    : MAX_PAGE_SIZE;
 
   // Only capture totalResults from the first (unfiltered) response.
   // Subsequent partitions with max_id return a smaller total_results

--- a/src/discord/search.ts
+++ b/src/discord/search.ts
@@ -165,9 +165,14 @@ const fetchPage = async (
     ? Math.min(params.limit, MAX_PAGE_SIZE)
     : MAX_PAGE_SIZE;
 
-  state.totalResults = maxMessages
-    ? Math.min(data.total_results, maxMessages)
-    : data.total_results;
+  // Only capture totalResults from the first (unfiltered) response.
+  // Subsequent partitions with max_id return a smaller total_results
+  // scoped to the filtered range, which would cause early termination.
+  if (state.totalResults === 0) {
+    state.totalResults = maxMessages
+      ? Math.min(data.total_results, maxMessages)
+      : data.total_results;
+  }
 
   let pageMessages = data.messages
     .map((group) => group[0])

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,36 +21,42 @@ const run = () => {
 
   if (parsed.version) {
     printVersion();
-    process.exit(0);
+    process.exitCode = 0;
+    return;
   }
 
   if (parsed.command === "help") {
     printHelp(parsed);
-    process.exit(0);
+    process.exitCode = 0;
+    return;
   }
 
   if (parsed.command === "interactive") {
     process.stderr.write(
       "Interactive mode is not yet implemented. Use 'discord-search search --help' for CLI usage.\n"
     );
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   if (parsed.command === "search") {
     process.stderr.write("Search command execution is not yet implemented.\n");
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   if (parsed.command === "preset") {
     process.stderr.write("Preset command execution is not yet implemented.\n");
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   if (parsed.command === "settings") {
     process.stderr.write(
       "Settings command execution is not yet implemented.\n"
     );
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,12 @@ const run = () => {
     process.exitCode = 1;
     return;
   }
+
+  const _exhaustive: never = parsed;
+  process.stderr.write(
+    `Unhandled command: ${(_exhaustive as ParsedArgs).command}\n`
+  );
+  process.exitCode = 1;
 };
 
 run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,55 @@
-/**
- * Discord Search CLI
- *
- * Entry point for the Discord message search tool.
- * This is a placeholder stub added during infrastructure setup.
- */
+#!/usr/bin/env node
 
-export {};
+import { HELP_TEXT, SUBCOMMAND_HELP } from "@/cli/args-help.ts";
+import { parseArgs } from "@/cli/args-parse.ts";
+import type { ParsedArgs } from "@/cli/args-types.ts";
+
+const printHelp = (parsed: ParsedArgs & { command: "help" }) => {
+  const target = parsed.targetCommand;
+  const helpText = target ? SUBCOMMAND_HELP[target] : HELP_TEXT;
+  process.stdout.write(`${helpText}\n`);
+};
+
+const printVersion = () => {
+  process.stdout.write("discord-search 0.0.0\n");
+};
+
+const run = () => {
+  const parsed = parseArgs(process.argv.slice(2));
+
+  if (parsed.version) {
+    printVersion();
+    process.exit(0);
+  }
+
+  if (parsed.command === "help") {
+    printHelp(parsed);
+    process.exit(0);
+  }
+
+  if (parsed.command === "interactive") {
+    process.stderr.write(
+      "Interactive mode is not yet implemented. Use 'discord-search search --help' for CLI usage.\n"
+    );
+    process.exit(1);
+  }
+
+  if (parsed.command === "search") {
+    process.stderr.write("Search command execution is not yet implemented.\n");
+    process.exit(1);
+  }
+
+  if (parsed.command === "preset") {
+    process.stderr.write("Preset command execution is not yet implemented.\n");
+    process.exit(1);
+  }
+
+  if (parsed.command === "settings") {
+    process.stderr.write(
+      "Settings command execution is not yet implemented.\n"
+    );
+    process.exit(1);
+  }
+};
+
+run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { HELP_TEXT, SUBCOMMAND_HELP } from "@/cli/args-help.ts";
 import { parseArgs } from "@/cli/args-parse.ts";
 import type { ParsedArgs } from "@/cli/args-types.ts";
 
+const VERSION = "0.0.0";
+
 const printHelp = (parsed: ParsedArgs & { command: "help" }) => {
   const target = parsed.targetCommand;
   const helpText = target ? SUBCOMMAND_HELP[target] : HELP_TEXT;
@@ -11,7 +13,7 @@ const printHelp = (parsed: ParsedArgs & { command: "help" }) => {
 };
 
 const printVersion = () => {
-  process.stdout.write("discord-search 0.0.0\n");
+  process.stdout.write(`discord-search ${VERSION}\n`);
 };
 
 const run = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,9 @@
 import { HELP_TEXT, SUBCOMMAND_HELP } from "@/cli/args-help.ts";
 import { parseArgs } from "@/cli/args-parse.ts";
 import type { ParsedArgs } from "@/cli/args-types.ts";
+import pkg from "../package.json";
 
-const VERSION = "0.0.0";
+const VERSION = pkg.version;
 
 const printHelp = (parsed: ParsedArgs & { command: "help" }) => {
   const target = parsed.targetCommand;


### PR DESCRIPTION
## Summary
- Add @clack/prompts wrappers for interactive user input (token, search params, menus)
- Add interactive message browser with j/k navigation and JSON toggle
- Add TTY key listener for live view toggle during search

## Stacked PR Chain
This is **PR 5 of 7** — merge in order.
`main` ← PR1 ← PR2 ← PR3 ← PR4 ← **PR5** ← PR6 ← PR7

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes linting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds interactive CLI components for Discord message search using `@clack/prompts`, a keyboard-driven message browser, and safer terminal cleanup. The CLI now routes help/version correctly (including subcommands), unifies `--limit` to cap total results, and tightens parser validation for presets and settings.

- **New Features**
  - Interactive UI: token/search prompts with strict snowflake (17–20 digits) validation and cancel; message browser with j/k/↑/↓/v/q/Esc, JSON toggle, non-TTY guard.
  - CLI: global `--help` and `--version` (works with subcommands, version read from `package.json`); adds `--guild` and `--client-id`; unimplemented subcommands print clear errors (exit 1).

- **Bug Fixes**
  - Help/version: `--help` without a subcommand shows global help; `search --help` short-circuits; `search --version` prints version without requiring `--guild`.
  - Pagination/rate limits: use actual request page size when `--limit` < max; `--limit` caps total fetched; only capture total results from the first page; track remapped bucket keys across retries.
  - Parser/settings: reject `preset run-all` when mixing `--all` with names; validate snowflakes for `settings set guild`/`client-id`; share `INTEGER_REGEX` and export `SNOWFLAKE_REGEX`; add exhaustiveness check for unknown commands; TTY/browser rendering fixes with 24-hour timestamps and truncated embed titles/fields.

<sup>Written for commit ce9b52e1386f3ff397689f258c6689659ea0d606. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

