### PR TITLE
feat: PR-7 add business logic handlers and CLI entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fix": "ultracite fix",
     "test": "bun test",
     "prepare": "lefthook install",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "prepublishOnly": "bun run typecheck && bun run check && bun run build",
     "version": "changeset version",
     "release": "changeset publish"

--- a/src/cli/args-parse.ts
+++ b/src/cli/args-parse.ts
@@ -393,6 +393,14 @@ const parsePresetRunAllAction = (
 ): PresetRunAllArgs => {
   const restArgs = remaining.slice(2);
   const flags = parseOutputFlags(restArgs, "preset");
+
+  if (flags.json) {
+    exitWithError(
+      "--json is not supported for 'preset run-all'. Use --export to export results.",
+      "preset run-all"
+    );
+  }
+
   const names: string[] = [];
   let all = false;
 
@@ -425,7 +433,6 @@ const parsePresetRunAllAction = (
       all,
       export: flags.export,
       outputDir: flags.outputDir,
-      json: flags.json,
       help: global.help,
       version: global.version,
       token: global.token,

--- a/src/cli/args-types.ts
+++ b/src/cli/args-types.ts
@@ -54,7 +54,6 @@ export const PresetRunAllArgsSchema = GlobalFlagsSchema.extend({
     .enum(["json", "csv-messages", "csv-embeds", "csv-fields", "all"])
     .optional(),
   outputDir: z.string().optional(),
-  json: z.boolean(),
 });
 
 export const PresetSaveArgsSchema = GlobalFlagsSchema.extend({

--- a/src/handlers/export.ts
+++ b/src/handlers/export.ts
@@ -12,12 +12,26 @@ import {
 } from "@/export.ts";
 import { OUTPUT_DIR } from "@/paths.ts";
 
+const VALID_EXPORT_FORMATS = new Set([
+  "json",
+  "csv-messages",
+  "csv-embeds",
+  "csv-fields",
+  "all",
+]);
+
 export const exportNonInteractive = async (
   data: ReturnType<typeof collateResults>,
   guildId: string,
   format: string,
   outputDir?: string
 ): Promise<string> => {
+  if (!VALID_EXPORT_FORMATS.has(format)) {
+    throw new Error(
+      `Invalid export format: "${format}". Valid formats: ${[...VALID_EXPORT_FORMATS].join(", ")}`
+    );
+  }
+
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const dir = outputDir ?? `${OUTPUT_DIR}/${guildId}-${timestamp}`;
 

--- a/src/handlers/export.ts
+++ b/src/handlers/export.ts
@@ -1,0 +1,99 @@
+import { mkdir } from "node:fs/promises";
+import { select, spinner, text } from "@clack/prompts";
+import { handleCancel } from "@/cli/prompts.ts";
+import type { collateResults } from "@/collate.ts";
+import {
+  exportEmbedsCsv,
+  exportFieldsCsv,
+  exportJson,
+  exportMessagesCsv,
+} from "@/export.ts";
+import { OUTPUT_DIR } from "@/paths.ts";
+
+export const exportNonInteractive = async (
+  data: ReturnType<typeof collateResults>,
+  guildId: string,
+  format: string,
+  outputDir?: string
+): Promise<string> => {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const dir = outputDir ?? `${OUTPUT_DIR}/${guildId}-${timestamp}`;
+
+  await mkdir(dir, { recursive: true });
+
+  const exports: Promise<unknown>[] = [];
+
+  if (format === "json" || format === "all") {
+    exports.push(exportJson(data, `${dir}/data.json`));
+  }
+  if (format === "csv-messages" || format === "all") {
+    exports.push(exportMessagesCsv(data, `${dir}/messages.csv`));
+  }
+  if (format === "csv-embeds" || format === "all") {
+    exports.push(exportEmbedsCsv(data, `${dir}/embeds.csv`));
+  }
+  if (format === "csv-fields" || format === "all") {
+    exports.push(exportFieldsCsv(data, `${dir}/fields.csv`));
+  }
+
+  await Promise.all(exports);
+  return dir;
+};
+
+export const handleExport = async (
+  data: ReturnType<typeof collateResults>,
+  guildId: string
+): Promise<void> => {
+  const format = await select({
+    message: "Export format:",
+    options: [
+      { value: "json", label: "JSON (full data)" },
+      { value: "messages", label: "CSV - Messages" },
+      { value: "embeds", label: "CSV - Embeds" },
+      { value: "fields", label: "CSV - Extracted Fields" },
+      { value: "all", label: "All of the above" },
+      { value: "none", label: "None (just view summary)" },
+    ],
+  });
+  handleCancel(format);
+
+  if (format === "none") {
+    return;
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const defaultDir = `${OUTPUT_DIR}/${guildId}-${timestamp}`;
+
+  const outputDir = await text({
+    message: "Output directory:",
+    initialValue: defaultDir,
+  });
+  handleCancel(outputDir);
+
+  const dir = (outputDir as string).trim();
+
+  const s = spinner();
+  s.start("Exporting...");
+
+  // Ensure directory exists
+  await mkdir(dir, { recursive: true });
+
+  const exports: Promise<unknown>[] = [];
+
+  if (format === "json" || format === "all") {
+    exports.push(exportJson(data, `${dir}/data.json`));
+  }
+  if (format === "messages" || format === "all") {
+    exports.push(exportMessagesCsv(data, `${dir}/messages.csv`));
+  }
+  if (format === "embeds" || format === "all") {
+    exports.push(exportEmbedsCsv(data, `${dir}/embeds.csv`));
+  }
+  if (format === "fields" || format === "all") {
+    exports.push(exportFieldsCsv(data, `${dir}/fields.csv`));
+  }
+
+  await Promise.all(exports);
+
+  s.stop(`Exported to ${dir}/`);
+};

--- a/src/handlers/export.ts
+++ b/src/handlers/export.ts
@@ -1,7 +1,9 @@
 import { mkdir } from "node:fs/promises";
 import { select, spinner, text } from "@clack/prompts";
+import type { Result } from "better-result";
 import { handleCancel } from "@/cli/prompts.ts";
 import type { collateResults } from "@/collate.ts";
+import type { ExportError } from "@/errors.ts";
 import {
   exportEmbedsCsv,
   exportFieldsCsv,
@@ -21,7 +23,7 @@ export const exportNonInteractive = async (
 
   await mkdir(dir, { recursive: true });
 
-  const exports: Promise<unknown>[] = [];
+  const exports: Promise<Result<void, ExportError>>[] = [];
 
   if (format === "json" || format === "all") {
     exports.push(exportJson(data, `${dir}/data.json`));
@@ -36,7 +38,12 @@ export const exportNonInteractive = async (
     exports.push(exportFieldsCsv(data, `${dir}/fields.csv`));
   }
 
-  await Promise.all(exports);
+  const results = await Promise.all(exports);
+  const failed = results.find((r) => r.isErr());
+  if (failed) {
+    throw failed.error;
+  }
+
   return dir;
 };
 
@@ -48,9 +55,9 @@ export const handleExport = async (
     message: "Export format:",
     options: [
       { value: "json", label: "JSON (full data)" },
-      { value: "messages", label: "CSV - Messages" },
-      { value: "embeds", label: "CSV - Embeds" },
-      { value: "fields", label: "CSV - Extracted Fields" },
+      { value: "csv-messages", label: "CSV - Messages" },
+      { value: "csv-embeds", label: "CSV - Embeds" },
+      { value: "csv-fields", label: "CSV - Extracted Fields" },
       { value: "all", label: "All of the above" },
       { value: "none", label: "None (just view summary)" },
     ],
@@ -78,22 +85,27 @@ export const handleExport = async (
   // Ensure directory exists
   await mkdir(dir, { recursive: true });
 
-  const exports: Promise<unknown>[] = [];
+  const exports: Promise<Result<void, ExportError>>[] = [];
 
   if (format === "json" || format === "all") {
     exports.push(exportJson(data, `${dir}/data.json`));
   }
-  if (format === "messages" || format === "all") {
+  if (format === "csv-messages" || format === "all") {
     exports.push(exportMessagesCsv(data, `${dir}/messages.csv`));
   }
-  if (format === "embeds" || format === "all") {
+  if (format === "csv-embeds" || format === "all") {
     exports.push(exportEmbedsCsv(data, `${dir}/embeds.csv`));
   }
-  if (format === "fields" || format === "all") {
+  if (format === "csv-fields" || format === "all") {
     exports.push(exportFieldsCsv(data, `${dir}/fields.csv`));
   }
 
-  await Promise.all(exports);
+  const results = await Promise.all(exports);
+  const failed = results.find((r) => r.isErr());
+  if (failed) {
+    s.stop(`Export failed: ${failed.error.message}`);
+    return;
+  }
 
   s.stop(`Exported to ${dir}/`);
 };

--- a/src/handlers/presets.ts
+++ b/src/handlers/presets.ts
@@ -335,6 +335,31 @@ export const runPresetNonInteractive = async (
   await executeNonInteractiveSearch(preset.params, token, options);
 };
 
+const tryExportPreset = async (
+  collated: ReturnType<typeof collateResults>,
+  preset: Preset,
+  options: { export: string; outputDir?: string },
+  timestamp: string
+): Promise<void> => {
+  try {
+    const safeName = sanitizePresetDirName(preset.name);
+    const dir = options.outputDir
+      ? `${options.outputDir}/${safeName}`
+      : `${OUTPUT_DIR}/${safeName}-${timestamp}`;
+    await exportNonInteractive(
+      collated,
+      preset.params.guildId,
+      options.export,
+      dir
+    );
+    process.stderr.write(`  Exported to ${dir}/\n`);
+  } catch (err) {
+    process.stderr.write(
+      `  Export failed: ${err instanceof Error ? err.message : String(err)}\n`
+    );
+  }
+};
+
 export const runAllPresetsNonInteractive = async (
   names: string[],
   all: boolean,
@@ -403,17 +428,12 @@ export const runAllPresetsNonInteractive = async (
     const collated = collateResults(result.value);
 
     if (options.export) {
-      const safeName = sanitizePresetDirName(preset.name);
-      const dir = options.outputDir
-        ? `${options.outputDir}/${safeName}`
-        : `${OUTPUT_DIR}/${safeName}-${timestamp}`;
-      await exportNonInteractive(
+      await tryExportPreset(
         collated,
-        preset.params.guildId,
-        options.export,
-        dir
+        preset,
+        { export: options.export, outputDir: options.outputDir },
+        timestamp
       );
-      process.stderr.write(`  Exported to ${dir}/\n`);
     }
   }
 

--- a/src/handlers/presets.ts
+++ b/src/handlers/presets.ts
@@ -22,6 +22,7 @@ import {
   displaySummary,
   executeNonInteractiveSearch,
 } from "@/handlers/search.ts";
+import { OUTPUT_DIR } from "@/paths.ts";
 import {
   deletePreset,
   loadPresets,
@@ -155,7 +156,7 @@ const runPresetSearch = async (
     return;
   }
 
-  const dir = `./output/${name}-${timestamp}`;
+  const dir = `${OUTPUT_DIR}/${name}-${timestamp}`;
   await Bun.write(`${dir}/.gitkeep`, "");
 
   const exports: Promise<unknown>[] = [];
@@ -345,7 +346,7 @@ export const runAllPresetsNonInteractive = async (
     if (options.export) {
       const dir = options.outputDir
         ? `${options.outputDir}/${preset.name}`
-        : `./output/${preset.name}-${timestamp}`;
+        : `${OUTPUT_DIR}/${preset.name}-${timestamp}`;
       await exportNonInteractive(
         collated,
         preset.params.guildId,

--- a/src/handlers/presets.ts
+++ b/src/handlers/presets.ts
@@ -121,9 +121,9 @@ const runPresetSearch = async (
   const s = spinner();
   s.start(`Searching: ${name}...`);
 
-  const result = await searchAllMessages(params, token, (fetched, total) => {
+  const result = await searchAllMessages(params, token, (progress) => {
     s.message(
-      `[${name}] Fetching... (${fetched.toLocaleString()} / ${total.toLocaleString()})`
+      `[${name}] Fetching... (${progress.fetched.toLocaleString()} / ${progress.total.toLocaleString()})`
     );
   });
 
@@ -310,9 +310,9 @@ export const runAllPresetsNonInteractive = async (
     const result = await searchAllMessages(
       preset.params,
       token,
-      (fetched, total) => {
+      (progress) => {
         process.stderr.write(
-          `\r  Fetching... (${fetched.toLocaleString()} / ${total.toLocaleString()})`
+          `\r  Fetching... (${progress.fetched.toLocaleString()} / ${progress.total.toLocaleString()})`
         );
       }
     );

--- a/src/handlers/presets.ts
+++ b/src/handlers/presets.ts
@@ -54,7 +54,11 @@ export const handleManagePresets = async (): Promise<void> => {
 
   if (presetAction !== "__back__") {
     const name = presetAction as string;
-    await deletePreset(name);
+    const result = await deletePreset(name);
+    if (result.isErr()) {
+      log.error(`Failed to delete preset: ${result.error.message}`);
+      return;
+    }
     log.success(`Deleted preset: ${name}`);
   }
 };
@@ -108,8 +112,12 @@ export const resolveSearchParams = async (
     });
     handleCancel(presetName);
     const savedName = (presetName as string).trim();
-    await savePreset(savedName, params);
-    log.success(`Saved preset: ${savedName}`);
+    const result = await savePreset(savedName, params);
+    if (result.isErr()) {
+      log.error(`Failed to save preset: ${result.error.message}`);
+    } else {
+      log.success(`Saved preset: ${savedName}`);
+    }
   }
 
   return params;

--- a/src/handlers/presets.ts
+++ b/src/handlers/presets.ts
@@ -33,9 +33,44 @@ import {
   savePreset,
 } from "@/presets.ts";
 
+const MAX_PRESET_DIR_NAME_LENGTH = 100;
+
+const isUnsafePathChar = (code: number): boolean =>
+  code <= 0x1f ||
+  code === 0x2f || // /
+  code === 0x5c || // \
+  code === 0x3a || // :
+  code === 0x2a || // *
+  code === 0x3f || // ?
+  code === 0x22 || // "
+  code === 0x3c || // <
+  code === 0x3e || // >
+  code === 0x7c || // |
+  code === 0x2e; // .
+
+const sanitizePresetDirName = (name: string): string => {
+  let sanitized = "";
+  for (
+    let i = 0;
+    i < name.length && sanitized.length < MAX_PRESET_DIR_NAME_LENGTH;
+    i++
+  ) {
+    const code = name.charCodeAt(i);
+    sanitized += isUnsafePathChar(code) ? "-" : name[i];
+  }
+  if (!sanitized || sanitized === "-") {
+    return "preset";
+  }
+  return sanitized;
+};
+
 export const handleManagePresets = async (): Promise<void> => {
   const presetsResult = await loadPresets();
-  if (presetsResult.isErr() || presetsResult.value.length === 0) {
+  if (presetsResult.isErr()) {
+    log.error(`Failed to load presets: ${presetsResult.error.message}`);
+    return;
+  }
+  if (presetsResult.value.length === 0) {
     log.info("No presets saved yet.");
     return;
   }
@@ -69,7 +104,11 @@ export const resolveSearchParams = async (
 ): Promise<SearchParams | null> => {
   if (action === "preset") {
     const presetsResult = await loadPresets();
-    if (presetsResult.isErr() || presetsResult.value.length === 0) {
+    if (presetsResult.isErr()) {
+      log.error(`Failed to load presets: ${presetsResult.error.message}`);
+      return null;
+    }
+    if (presetsResult.value.length === 0) {
       log.info("No presets saved yet. Starting new search.");
       return await promptForSearchParams(defaultGuildId);
     }
@@ -167,7 +206,7 @@ const runPresetSearch = async (
     return;
   }
 
-  const dir = `${OUTPUT_DIR}/${name}-${timestamp}`;
+  const dir = `${OUTPUT_DIR}/${sanitizePresetDirName(name)}-${timestamp}`;
   await mkdir(dir, { recursive: true });
 
   const exports: Promise<Result<void, ExportError>>[] = [];
@@ -360,9 +399,10 @@ export const runAllPresetsNonInteractive = async (
     const collated = collateResults(result.value);
 
     if (options.export) {
+      const safeName = sanitizePresetDirName(preset.name);
       const dir = options.outputDir
-        ? `${options.outputDir}/${preset.name}`
-        : `${OUTPUT_DIR}/${preset.name}-${timestamp}`;
+        ? `${options.outputDir}/${safeName}`
+        : `${OUTPUT_DIR}/${safeName}-${timestamp}`;
       await exportNonInteractive(
         collated,
         preset.params.guildId,

--- a/src/handlers/presets.ts
+++ b/src/handlers/presets.ts
@@ -1,3 +1,4 @@
+import { mkdir } from "node:fs/promises";
 import {
   confirm,
   log,
@@ -6,11 +7,13 @@ import {
   spinner,
   text,
 } from "@clack/prompts";
+import type { Result } from "better-result";
 import { matchError } from "better-result";
 import { handleCancel, promptForSearchParams } from "@/cli/prompts.ts";
 import { collateResults } from "@/collate.ts";
 import type { SearchParams } from "@/discord/schemas.ts";
 import { searchAllMessages } from "@/discord/search.ts";
+import type { ExportError } from "@/errors.ts";
 import {
   exportEmbedsCsv,
   exportFieldsCsv,
@@ -157,9 +160,9 @@ const runPresetSearch = async (
   }
 
   const dir = `${OUTPUT_DIR}/${name}-${timestamp}`;
-  await Bun.write(`${dir}/.gitkeep`, "");
+  await mkdir(dir, { recursive: true });
 
-  const exports: Promise<unknown>[] = [];
+  const exports: Promise<Result<void, ExportError>>[] = [];
   if (format === "json" || format === "all") {
     exports.push(exportJson(collated, `${dir}/data.json`));
   }
@@ -168,7 +171,12 @@ const runPresetSearch = async (
     exports.push(exportEmbedsCsv(collated, `${dir}/embeds.csv`));
     exports.push(exportFieldsCsv(collated, `${dir}/fields.csv`));
   }
-  await Promise.all(exports);
+  const results = await Promise.all(exports);
+  const failed = results.find((r) => r.isErr());
+  if (failed) {
+    log.error(`Export failed for ${name}: ${failed.error.message}`);
+    return;
+  }
   log.info(`Exported to ${dir}/`);
 };
 

--- a/src/handlers/presets.ts
+++ b/src/handlers/presets.ts
@@ -229,7 +229,11 @@ const runPresetSearch = async (
 
 export const handleRunAllPresets = async (token: string): Promise<void> => {
   const presetsResult = await loadPresets();
-  if (presetsResult.isErr() || presetsResult.value.length === 0) {
+  if (presetsResult.isErr()) {
+    log.error(`Failed to load presets: ${presetsResult.error.message}`);
+    return;
+  }
+  if (presetsResult.value.length === 0) {
     log.info("No presets saved yet.");
     return;
   }

--- a/src/handlers/presets.ts
+++ b/src/handlers/presets.ts
@@ -307,15 +307,11 @@ export const runAllPresetsNonInteractive = async (
       `[${i + 1}/${presets.length}] Running preset: ${preset.name}\n`
     );
 
-    const result = await searchAllMessages(
-      preset.params,
-      token,
-      (progress) => {
-        process.stderr.write(
-          `\r  Fetching... (${progress.fetched.toLocaleString()} / ${progress.total.toLocaleString()})`
-        );
-      }
-    );
+    const result = await searchAllMessages(preset.params, token, (progress) => {
+      process.stderr.write(
+        `\r  Fetching... (${progress.fetched.toLocaleString()} / ${progress.total.toLocaleString()})`
+      );
+    });
     process.stderr.write("\n");
 
     if (result.isErr()) {

--- a/src/handlers/presets.ts
+++ b/src/handlers/presets.ts
@@ -1,0 +1,391 @@
+import {
+  confirm,
+  log,
+  multiselect,
+  select,
+  spinner,
+  text,
+} from "@clack/prompts";
+import { matchError } from "better-result";
+import { handleCancel, promptForSearchParams } from "@/cli/prompts.ts";
+import { collateResults } from "@/collate.ts";
+import type { SearchParams } from "@/discord/schemas.ts";
+import { searchAllMessages } from "@/discord/search.ts";
+import {
+  exportEmbedsCsv,
+  exportFieldsCsv,
+  exportJson,
+  exportMessagesCsv,
+} from "@/export.ts";
+import { exportNonInteractive } from "@/handlers/export.ts";
+import {
+  displaySummary,
+  executeNonInteractiveSearch,
+} from "@/handlers/search.ts";
+import {
+  deletePreset,
+  loadPresets,
+  type Preset,
+  savePreset,
+} from "@/presets.ts";
+
+export const handleManagePresets = async (): Promise<void> => {
+  const presetsResult = await loadPresets();
+  if (presetsResult.isErr() || presetsResult.value.length === 0) {
+    log.info("No presets saved yet.");
+    return;
+  }
+
+  const presetAction = await select({
+    message: "Select a preset to delete:",
+    options: [
+      ...presetsResult.value.map((p) => ({
+        value: p.name,
+        label: `${p.name} (guild: ${p.params.guildId})`,
+      })),
+      { value: "__back__", label: "Back" },
+    ],
+  });
+  handleCancel(presetAction);
+
+  if (presetAction !== "__back__") {
+    const name = presetAction as string;
+    await deletePreset(name);
+    log.success(`Deleted preset: ${name}`);
+  }
+};
+
+export const resolveSearchParams = async (
+  action: string,
+  defaultGuildId?: string
+): Promise<SearchParams | null> => {
+  if (action === "preset") {
+    const presetsResult = await loadPresets();
+    if (presetsResult.isErr() || presetsResult.value.length === 0) {
+      log.info("No presets saved yet. Starting new search.");
+      return await promptForSearchParams(defaultGuildId);
+    }
+
+    const presetName = await select({
+      message: "Select a preset:",
+      options: presetsResult.value.map((p) => ({
+        value: p.name,
+        label: `${p.name} (guild: ${p.params.guildId})`,
+      })),
+    });
+    handleCancel(presetName);
+
+    const preset = presetsResult.value.find((p) => p.name === presetName);
+    if (!preset) {
+      log.error("Preset not found.");
+      return null;
+    }
+
+    log.info(`Loaded preset: ${preset.name}`);
+    return preset.params;
+  }
+
+  const params = await promptForSearchParams(defaultGuildId);
+
+  const shouldSave = await confirm({
+    message: "Save as preset?",
+    initialValue: false,
+  });
+  handleCancel(shouldSave);
+
+  if (shouldSave) {
+    const presetName = await text({
+      message: "Preset name:",
+      validate: (v) => {
+        if (!v?.trim()) {
+          return "Name is required";
+        }
+      },
+    });
+    handleCancel(presetName);
+    const savedName = (presetName as string).trim();
+    await savePreset(savedName, params);
+    log.success(`Saved preset: ${savedName}`);
+  }
+
+  return params;
+};
+
+const runPresetSearch = async (
+  name: string,
+  params: SearchParams,
+  token: string,
+  format: string,
+  timestamp: string
+): Promise<void> => {
+  const s = spinner();
+  s.start(`Searching: ${name}...`);
+
+  const result = await searchAllMessages(params, token, (fetched, total) => {
+    s.message(
+      `[${name}] Fetching... (${fetched.toLocaleString()} / ${total.toLocaleString()})`
+    );
+  });
+
+  if (result.isErr()) {
+    s.stop(`Search failed for: ${name}`);
+    matchError(result.error, {
+      DiscordApiError: (e) =>
+        log.error(`API error (${e.status}): ${e.message}`),
+      RateLimitExhaustedError: (e) =>
+        log.error(`Rate limited. Try again in ${e.retryAfter}s.`),
+      IndexNotReadyError: (e) =>
+        log.error(`Index not ready. Try again in ${e.retryAfter}s.`),
+      ValidationError: (e) =>
+        log.error(`Response validation failed: ${e.message}`),
+    });
+    return;
+  }
+
+  s.stop(`[${name}] Found ${result.value.length.toLocaleString()} messages.`);
+
+  if (result.value.length === 0) {
+    return;
+  }
+
+  const collated = collateResults(result.value);
+  displaySummary(collated);
+
+  if (format === "none") {
+    return;
+  }
+
+  const dir = `./output/${name}-${timestamp}`;
+  await Bun.write(`${dir}/.gitkeep`, "");
+
+  const exports: Promise<unknown>[] = [];
+  if (format === "json" || format === "all") {
+    exports.push(exportJson(collated, `${dir}/data.json`));
+  }
+  if (format === "all") {
+    exports.push(exportMessagesCsv(collated, `${dir}/messages.csv`));
+    exports.push(exportEmbedsCsv(collated, `${dir}/embeds.csv`));
+    exports.push(exportFieldsCsv(collated, `${dir}/fields.csv`));
+  }
+  await Promise.all(exports);
+  log.info(`Exported to ${dir}/`);
+};
+
+export const handleRunAllPresets = async (token: string): Promise<void> => {
+  const presetsResult = await loadPresets();
+  if (presetsResult.isErr() || presetsResult.value.length === 0) {
+    log.info("No presets saved yet.");
+    return;
+  }
+
+  const allPresets = presetsResult.value;
+
+  const selected = await multiselect({
+    message: "Select presets to run:",
+    options: allPresets.map((p) => ({
+      value: p.name,
+      label: `${p.name} (guild: ${p.params.guildId}${p.params.content ? `, content: ${p.params.content}` : ""})`,
+    })),
+    required: true,
+  });
+  handleCancel(selected);
+
+  const selectedNames = new Set(selected as string[]);
+  const presets = allPresets.filter((p) => selectedNames.has(p.name));
+
+  log.info(`Running ${presets.length} preset(s) sequentially...`);
+
+  const format = await select({
+    message: "Export format for all results:",
+    options: [
+      { value: "json", label: "JSON (full data)" },
+      { value: "all", label: "All formats (JSON + CSVs)" },
+      { value: "none", label: "None (just view summaries)" },
+    ],
+  });
+  handleCancel(format);
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+  for (let i = 0; i < presets.length; i++) {
+    const preset = presets[i];
+    if (!preset) {
+      continue;
+    }
+
+    log.step(`[${i + 1}/${presets.length}] Running preset: ${preset.name}`);
+    await runPresetSearch(
+      preset.name,
+      preset.params,
+      token,
+      format as string,
+      timestamp
+    );
+  }
+
+  log.success(`Finished running all ${presets.length} preset(s).`);
+};
+
+// --- Non-interactive preset operations ---
+
+const loadPresetsOrExit = async (): Promise<Preset[]> => {
+  const result = await loadPresets();
+  if (result.isErr()) {
+    process.stderr.write("Failed to load presets.\n");
+    process.exit(1);
+  }
+  return result.value;
+};
+
+const findPresetOrExit = (presets: Preset[], name: string): Preset => {
+  const preset = presets.find((p) => p.name === name);
+  if (!preset) {
+    process.stderr.write(`Preset not found: ${name}\n`);
+    process.exit(1);
+  }
+  return preset;
+};
+
+export const listPresetsNonInteractive = async (): Promise<void> => {
+  const presets = await loadPresetsOrExit();
+  if (presets.length === 0) {
+    process.stdout.write("No presets saved.\n");
+    return;
+  }
+  for (const p of presets) {
+    const details = [
+      `guild:${p.params.guildId}`,
+      p.params.content ? `content:"${p.params.content}"` : "",
+      p.params.channelId ? `channels:${p.params.channelId.join(",")}` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    process.stdout.write(`${p.name}  ${details}\n`);
+  }
+};
+
+export const runPresetNonInteractive = async (
+  name: string,
+  token: string,
+  options: { export?: string; outputDir?: string; json: boolean }
+): Promise<void> => {
+  const presets = await loadPresetsOrExit();
+  const preset = findPresetOrExit(presets, name);
+  process.stderr.write(`Running preset: ${preset.name}\n`);
+  await executeNonInteractiveSearch(preset.params, token, options);
+};
+
+export const runAllPresetsNonInteractive = async (
+  names: string[],
+  all: boolean,
+  token: string,
+  options: { export?: string; outputDir?: string }
+): Promise<void> => {
+  const allPresets = await loadPresetsOrExit();
+  if (allPresets.length === 0) {
+    process.stderr.write("No presets saved.\n");
+    return;
+  }
+
+  const presets = all
+    ? allPresets
+    : names.map((name) => findPresetOrExit(allPresets, name));
+
+  if (presets.length === 0) {
+    process.stderr.write("No presets selected.\n");
+    return;
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+  for (let i = 0; i < presets.length; i++) {
+    const preset = presets[i];
+    if (!preset) {
+      continue;
+    }
+    process.stderr.write(
+      `[${i + 1}/${presets.length}] Running preset: ${preset.name}\n`
+    );
+
+    const result = await searchAllMessages(
+      preset.params,
+      token,
+      (fetched, total) => {
+        process.stderr.write(
+          `\r  Fetching... (${fetched.toLocaleString()} / ${total.toLocaleString()})`
+        );
+      }
+    );
+    process.stderr.write("\n");
+
+    if (result.isErr()) {
+      matchError(result.error, {
+        DiscordApiError: (e) =>
+          process.stderr.write(`  API error (${e.status}): ${e.message}\n`),
+        RateLimitExhaustedError: (e) =>
+          process.stderr.write(
+            `  Rate limited. Try again in ${e.retryAfter}s.\n`
+          ),
+        IndexNotReadyError: (e) =>
+          process.stderr.write(
+            `  Index not ready. Try again in ${e.retryAfter}s.\n`
+          ),
+        ValidationError: (e) =>
+          process.stderr.write(`  Response validation failed: ${e.message}\n`),
+      });
+      continue;
+    }
+
+    process.stderr.write(
+      `  Found ${result.value.length.toLocaleString()} messages.\n`
+    );
+
+    if (result.value.length === 0) {
+      continue;
+    }
+
+    const collated = collateResults(result.value);
+
+    if (options.export) {
+      const dir = options.outputDir
+        ? `${options.outputDir}/${preset.name}`
+        : `./output/${preset.name}-${timestamp}`;
+      await exportNonInteractive(
+        collated,
+        preset.params.guildId,
+        options.export,
+        dir
+      );
+      process.stderr.write(`  Exported to ${dir}/\n`);
+    }
+  }
+
+  process.stderr.write(`Finished running ${presets.length} preset(s).\n`);
+};
+
+export const savePresetNonInteractive = async (
+  name: string,
+  params: SearchParams
+): Promise<void> => {
+  if (!params.guildId) {
+    process.stderr.write("Error: --guild is required when saving a preset.\n");
+    process.exit(1);
+  }
+  const result = await savePreset(name, params);
+  if (result.isErr()) {
+    process.stderr.write(`Failed to save preset: ${name}\n`);
+    process.exit(1);
+  }
+  process.stderr.write(`Saved preset: ${name}\n`);
+};
+
+export const deletePresetNonInteractive = async (
+  name: string
+): Promise<void> => {
+  const result = await deletePreset(name);
+  if (result.isErr()) {
+    process.stderr.write(`Failed to delete preset: ${name}\n`);
+    process.exit(1);
+  }
+  process.stderr.write(`Deleted preset: ${name}\n`);
+};

--- a/src/handlers/search.ts
+++ b/src/handlers/search.ts
@@ -132,9 +132,9 @@ export const executeSearch = async (
   const result = await searchAllMessages(
     searchParams,
     token,
-    (fetched, total) => {
+    (progress) => {
       s.message(
-        `Fetching messages... (${fetched.toLocaleString()} / ${total.toLocaleString()})${liveView ? " [LIVE]" : ""}`
+        `Fetching messages... (${progress.fetched.toLocaleString()} / ${progress.total.toLocaleString()})${liveView ? " [LIVE]" : ""}`
       );
     },
     (pageMessages) => {
@@ -188,9 +188,9 @@ export const executeNonInteractiveSearch = async (
   const result = await searchAllMessages(
     searchParams,
     token,
-    (fetched, total) => {
+    (progress) => {
       process.stderr.write(
-        `\rFetching messages... (${fetched.toLocaleString()} / ${total.toLocaleString()})`
+        `\rFetching messages... (${progress.fetched.toLocaleString()} / ${progress.total.toLocaleString()})`
       );
     }
   );

--- a/src/handlers/search.ts
+++ b/src/handlers/search.ts
@@ -185,15 +185,11 @@ export const executeNonInteractiveSearch = async (
     json: boolean;
   }
 ): Promise<void> => {
-  const result = await searchAllMessages(
-    searchParams,
-    token,
-    (progress) => {
-      process.stderr.write(
-        `\rFetching messages... (${progress.fetched.toLocaleString()} / ${progress.total.toLocaleString()})`
-      );
-    }
-  );
+  const result = await searchAllMessages(searchParams, token, (progress) => {
+    process.stderr.write(
+      `\rFetching messages... (${progress.fetched.toLocaleString()} / ${progress.total.toLocaleString()})`
+    );
+  });
 
   process.stderr.write("\n");
 

--- a/src/handlers/search.ts
+++ b/src/handlers/search.ts
@@ -1,0 +1,245 @@
+import { log, select, spinner } from "@clack/prompts";
+import { matchError } from "better-result";
+import { ANSI_DIM, ANSI_RESET } from "@/cli/ansi.ts";
+import { browseMessages } from "@/cli/browser.ts";
+import { createKeyListener } from "@/cli/keys.ts";
+import { handleCancel } from "@/cli/prompts.ts";
+import { collateResults } from "@/collate.ts";
+import type { Message, SearchParams } from "@/discord/schemas.ts";
+import { searchAllMessages } from "@/discord/search.ts";
+import { exportNonInteractive, handleExport } from "@/handlers/export.ts";
+
+export const displaySummary = (
+  data: ReturnType<typeof collateResults>
+): void => {
+  log.info(`Total messages: ${data.totalMessages}`);
+  log.info(`Total embeds: ${data.totalEmbeds}`);
+
+  // Top authors
+  const authors = Object.entries(data.byAuthor)
+    .sort(([, a], [, b]) => b.count - a.count)
+    .slice(0, 10);
+
+  if (authors.length > 0) {
+    const authorLines = authors
+      .map(
+        ([id, info]) =>
+          `  ${info.username}${info.bot ? " [BOT]" : ""} (${id}): ${info.count}`
+      )
+      .join("\n");
+    log.info(`Top authors:\n${authorLines}`);
+  }
+
+  // Embed type breakdown
+  if (Object.keys(data.embedsByType).length > 0) {
+    const typeLines = Object.entries(data.embedsByType)
+      .sort(([, a], [, b]) => b - a)
+      .map(([type, count]) => `  ${type}: ${count}`)
+      .join("\n");
+    log.info(`Embed types:\n${typeLines}`);
+  }
+
+  // Top providers
+  if (Object.keys(data.embedsByProvider).length > 0) {
+    const providerLines = Object.entries(data.embedsByProvider)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 10)
+      .map(([provider, count]) => `  ${provider}: ${count}`)
+      .join("\n");
+    log.info(`Top embed providers:\n${providerLines}`);
+  }
+
+  // Top domains
+  if (Object.keys(data.embedsByDomain).length > 0) {
+    const domainLines = Object.entries(data.embedsByDomain)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 10)
+      .map(([domain, count]) => `  ${domain}: ${count}`)
+      .join("\n");
+    log.info(`Top embed domains:\n${domainLines}`);
+  }
+
+  // Extracted field names
+  if (data.extractedFields.length > 0) {
+    const fieldNames = new Set<string>();
+    for (const row of data.extractedFields) {
+      for (const name of Object.keys(row.fields)) {
+        fieldNames.add(name);
+      }
+    }
+    if (fieldNames.size > 0) {
+      log.info(
+        `Extracted ${data.extractedFields.length} field rows with columns: ${[...fieldNames].join(", ")}`
+      );
+    }
+  }
+};
+
+const handlePostSearch = async (
+  collated: ReturnType<typeof collateResults>,
+  messages: Message[],
+  guildId: string
+): Promise<void> => {
+  while (true) {
+    const action = await select({
+      message: "What next?",
+      options: [
+        {
+          value: "browse",
+          label: "Browse messages [j/k to navigate, v for JSON]",
+        },
+        { value: "export", label: "Export results" },
+        { value: "done", label: "Done" },
+      ],
+    });
+    handleCancel(action);
+
+    if (action === "done") {
+      return;
+    }
+
+    if (action === "browse") {
+      await browseMessages(messages);
+    }
+
+    if (action === "export") {
+      await handleExport(collated, guildId);
+    }
+  }
+};
+
+export const executeSearch = async (
+  searchParams: SearchParams,
+  token: string
+): Promise<void> => {
+  let liveView = false;
+  log.info(
+    `${ANSI_DIM}Press [v] during search to toggle live JSON output${ANSI_RESET}`
+  );
+
+  const s = spinner();
+  s.start("Searching...");
+
+  const cleanupKeys = createKeyListener((key) => {
+    if (key === "v") {
+      liveView = !liveView;
+      s.message(
+        liveView ? "Live view ON — streaming results..." : "Live view OFF"
+      );
+    }
+  });
+
+  const result = await searchAllMessages(
+    searchParams,
+    token,
+    (fetched, total) => {
+      s.message(
+        `Fetching messages... (${fetched.toLocaleString()} / ${total.toLocaleString()})${liveView ? " [LIVE]" : ""}`
+      );
+    },
+    (pageMessages) => {
+      if (!liveView) {
+        return;
+      }
+      for (const msg of pageMessages) {
+        process.stdout.write(`\n${JSON.stringify(msg)}\n`);
+      }
+    }
+  );
+
+  cleanupKeys();
+
+  if (result.isErr()) {
+    s.stop("Search failed.");
+    matchError(result.error, {
+      DiscordApiError: (e) =>
+        log.error(`API error (${e.status}): ${e.message}`),
+      RateLimitExhaustedError: (e) =>
+        log.error(`Rate limited. Try again in ${e.retryAfter}s.`),
+      IndexNotReadyError: (e) =>
+        log.error(`Index not ready. Try again in ${e.retryAfter}s.`),
+      ValidationError: (e) =>
+        log.error(`Response validation failed: ${e.message}`),
+    });
+    return;
+  }
+
+  s.stop(`Found ${result.value.length.toLocaleString()} messages.`);
+
+  if (result.value.length === 0) {
+    log.info("No messages matched your search.");
+    return;
+  }
+
+  const collated = collateResults(result.value);
+  displaySummary(collated);
+  await handlePostSearch(collated, result.value, searchParams.guildId);
+};
+
+export const executeNonInteractiveSearch = async (
+  searchParams: SearchParams,
+  token: string,
+  options: {
+    export?: string;
+    outputDir?: string;
+    json: boolean;
+  }
+): Promise<void> => {
+  const result = await searchAllMessages(
+    searchParams,
+    token,
+    (fetched, total) => {
+      process.stderr.write(
+        `\rFetching messages... (${fetched.toLocaleString()} / ${total.toLocaleString()})`
+      );
+    }
+  );
+
+  process.stderr.write("\n");
+
+  if (result.isErr()) {
+    matchError(result.error, {
+      DiscordApiError: (e) =>
+        process.stderr.write(`API error (${e.status}): ${e.message}\n`),
+      RateLimitExhaustedError: (e) =>
+        process.stderr.write(`Rate limited. Try again in ${e.retryAfter}s.\n`),
+      IndexNotReadyError: (e) =>
+        process.stderr.write(
+          `Index not ready. Try again in ${e.retryAfter}s.\n`
+        ),
+      ValidationError: (e) =>
+        process.stderr.write(`Response validation failed: ${e.message}\n`),
+    });
+    process.exit(1);
+  }
+
+  const messages = result.value;
+  process.stderr.write(`Found ${messages.length.toLocaleString()} messages.\n`);
+
+  if (messages.length === 0) {
+    if (options.json) {
+      process.stdout.write('{"totalMessages":0,"messages":[]}\n');
+    }
+    return;
+  }
+
+  const collated = collateResults(messages);
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(collated)}\n`);
+  }
+
+  if (options.export) {
+    const dir = await exportNonInteractive(
+      collated,
+      searchParams.guildId,
+      options.export,
+      options.outputDir
+    );
+    process.stderr.write(`Exported to ${dir}/\n`);
+  }
+
+  if (!(options.json || options.export)) {
+    displaySummary(collated);
+  }
+};

--- a/src/handlers/search.ts
+++ b/src/handlers/search.ts
@@ -214,7 +214,7 @@ export const executeNonInteractiveSearch = async (
 
   if (messages.length === 0) {
     if (options.json) {
-      process.stdout.write('{"totalMessages":0,"messages":[]}\n');
+      process.stdout.write(`${JSON.stringify(collateResults([]))}\n`);
     }
     return;
   }

--- a/src/handlers/settings.ts
+++ b/src/handlers/settings.ts
@@ -167,12 +167,14 @@ export const setSettingNonInteractive = async (
   value: string,
   state: AppState
 ): Promise<void> => {
+  const normalized = value.trim() || undefined;
+
   if (key === "token") {
-    state.token = value;
+    state.token = normalized;
   } else if (key === "client-id") {
-    state.clientId = value;
+    state.clientId = normalized;
   } else if (key === "guild") {
-    state.defaultGuildId = value;
+    state.defaultGuildId = normalized;
   } else {
     process.stderr.write(
       `Unknown setting: ${key}. Valid keys: token, client-id, guild\n`

--- a/src/handlers/settings.ts
+++ b/src/handlers/settings.ts
@@ -1,0 +1,201 @@
+import { confirm, log, password, select, text } from "@clack/prompts";
+import { handleCancel, promptForToken } from "@/cli/prompts.ts";
+import { generateInviteLink, type loadConfig, saveSettings } from "@/config.ts";
+import type { AppState } from "@/types.ts";
+
+const showCurrentSettings = (state: AppState): void => {
+  const lines = [
+    `  Bot token: ${state.token ? `***${state.token.slice(-6)}` : "(not set)"}`,
+    `  Client ID: ${state.clientId ?? "(not set)"}`,
+    `  Default guild: ${state.defaultGuildId ?? "(not set)"}`,
+  ];
+  log.info(`Current settings:\n${lines.join("\n")}`);
+};
+
+export const saveStateToSettings = async (state: AppState): Promise<void> => {
+  const values: { token: string; clientId?: string; guildId?: string } = {
+    token: state.token,
+  };
+  if (state.clientId) {
+    values.clientId = state.clientId;
+  }
+  if (state.defaultGuildId) {
+    values.guildId = state.defaultGuildId;
+  }
+
+  const result = await saveSettings(values);
+  if (result.isOk()) {
+    log.success("Saved settings to ~/.discord-search/settings.json");
+  } else {
+    log.error("Failed to save settings.");
+  }
+};
+
+const handleSettingsAction = async (
+  action: string,
+  state: AppState
+): Promise<void> => {
+  if (action === "token") {
+    const newToken = await password({ message: "Enter new bot token:" });
+    handleCancel(newToken);
+    state.token = newToken as string;
+    log.success("Bot token updated.");
+  }
+
+  if (action === "client-id") {
+    const input = await text({
+      message: "Enter Discord Application Client ID:",
+      initialValue: state.clientId ?? "",
+    });
+    handleCancel(input);
+    state.clientId = (input as string).trim() || undefined;
+    log.success("Client ID updated.");
+  }
+
+  if (action === "guild") {
+    const input = await text({
+      message: "Enter default guild/server ID:",
+      initialValue: state.defaultGuildId ?? "",
+    });
+    handleCancel(input);
+    state.defaultGuildId = (input as string).trim() || undefined;
+    log.success("Default guild ID updated.");
+  }
+
+  if (action === "invite") {
+    const clientId = state.clientId;
+    if (!clientId) {
+      log.warn("Set a Client ID first.");
+      return;
+    }
+    const link = generateInviteLink(clientId);
+    log.info(`Bot invite link:\n  ${link}`);
+  }
+
+  if (action === "save") {
+    await saveStateToSettings(state);
+  }
+};
+
+export const handleSettings = async (state: AppState): Promise<void> => {
+  while (true) {
+    showCurrentSettings(state);
+
+    const action = await select({
+      message: "Settings:",
+      options: [
+        { value: "token", label: "Update bot token" },
+        { value: "client-id", label: "Update client ID" },
+        { value: "guild", label: "Set default guild/server ID" },
+        { value: "invite", label: "Generate bot invite link" },
+        { value: "save", label: "Save settings" },
+        { value: "back", label: "Back" },
+      ],
+    });
+    handleCancel(action);
+
+    if (action === "back") {
+      break;
+    }
+
+    await handleSettingsAction(action as string, state);
+  }
+};
+
+export const resolveToken = async (
+  cliToken: string | undefined,
+  configResult: Awaited<ReturnType<typeof loadConfig>>
+): Promise<string> => {
+  if (cliToken) {
+    return cliToken;
+  }
+  if (configResult.isOk()) {
+    return configResult.value.token;
+  }
+
+  log.warn("No DISCORD_BOT_TOKEN found in environment or settings.");
+  const token = await promptForToken();
+
+  const shouldSave = await confirm({
+    message: "Save token to settings?",
+    initialValue: true,
+  });
+  handleCancel(shouldSave);
+
+  if (shouldSave) {
+    await saveStateToSettings({
+      token,
+      clientId: undefined,
+      defaultGuildId: undefined,
+    });
+  }
+
+  return token;
+};
+
+// --- Non-interactive settings operations ---
+
+export const resolveTokenNonInteractive = (
+  cliToken: string | undefined,
+  configResult: Awaited<ReturnType<typeof loadConfig>>
+): string => {
+  if (cliToken) {
+    return cliToken;
+  }
+  if (configResult.isOk()) {
+    return configResult.value.token;
+  }
+  process.stderr.write(
+    "Error: No token found. Provide --token or set DISCORD_BOT_TOKEN.\n"
+  );
+  process.exit(1);
+};
+
+export const showSettingsNonInteractive = (state: AppState): void => {
+  process.stdout.write(
+    JSON.stringify(
+      {
+        token: state.token ? `***${state.token.slice(-6)}` : null,
+        clientId: state.clientId ?? null,
+        defaultGuildId: state.defaultGuildId ?? null,
+      },
+      null,
+      2
+    )
+  );
+  process.stdout.write("\n");
+};
+
+export const setSettingNonInteractive = async (
+  key: string,
+  value: string,
+  state: AppState
+): Promise<void> => {
+  if (key === "token") {
+    state.token = value;
+  } else if (key === "client-id") {
+    state.clientId = value;
+  } else if (key === "guild") {
+    state.defaultGuildId = value;
+  } else {
+    process.stderr.write(
+      `Unknown setting: ${key}. Valid keys: token, client-id, guild\n`
+    );
+    process.exit(1);
+  }
+
+  await saveStateToSettings(state);
+  process.stderr.write(`Updated ${key}.\n`);
+};
+
+export const showInviteLinkNonInteractive = (
+  clientId: string | undefined
+): void => {
+  if (!clientId) {
+    process.stderr.write(
+      "Error: Client ID required. Use --client-id or set DISCORD_CLIENT_ID.\n"
+    );
+    process.exit(1);
+  }
+  process.stdout.write(`${generateInviteLink(clientId)}\n`);
+};

--- a/src/handlers/settings.ts
+++ b/src/handlers/settings.ts
@@ -1,4 +1,5 @@
 import { confirm, log, password, select, text } from "@clack/prompts";
+import { Result } from "better-result";
 import { handleCancel, promptForToken } from "@/cli/prompts.ts";
 import { generateInviteLink, type loadConfig, saveSettings } from "@/config.ts";
 import type { AppState } from "@/types.ts";
@@ -13,9 +14,10 @@ const showCurrentSettings = (state: AppState): void => {
 };
 
 export const saveStateToSettings = async (state: AppState): Promise<void> => {
-  const values: { token: string; clientId?: string; guildId?: string } = {
-    token: state.token,
-  };
+  const values: { token?: string; clientId?: string; guildId?: string } = {};
+  if (state.token) {
+    values.token = state.token;
+  }
   if (state.clientId) {
     values.clientId = state.clientId;
   }
@@ -40,9 +42,7 @@ const handleSettingsAction = async (
     handleCancel(newToken);
     state.token = newToken as string;
     log.success("Bot token updated.");
-  }
-
-  if (action === "client-id") {
+  } else if (action === "client-id") {
     const input = await text({
       message: "Enter Discord Application Client ID:",
       initialValue: state.clientId ?? "",
@@ -50,9 +50,7 @@ const handleSettingsAction = async (
     handleCancel(input);
     state.clientId = (input as string).trim() || undefined;
     log.success("Client ID updated.");
-  }
-
-  if (action === "guild") {
+  } else if (action === "guild") {
     const input = await text({
       message: "Enter default guild/server ID:",
       initialValue: state.defaultGuildId ?? "",
@@ -60,9 +58,7 @@ const handleSettingsAction = async (
     handleCancel(input);
     state.defaultGuildId = (input as string).trim() || undefined;
     log.success("Default guild ID updated.");
-  }
-
-  if (action === "invite") {
+  } else if (action === "invite") {
     const clientId = state.clientId;
     if (!clientId) {
       log.warn("Set a Client ID first.");
@@ -70,9 +66,7 @@ const handleSettingsAction = async (
     }
     const link = generateInviteLink(clientId);
     log.info(`Bot invite link:\n  ${link}`);
-  }
-
-  if (action === "save") {
+  } else if (action === "save") {
     await saveStateToSettings(state);
   }
 };
@@ -138,17 +132,16 @@ export const resolveToken = async (
 export const resolveTokenNonInteractive = (
   cliToken: string | undefined,
   configResult: Awaited<ReturnType<typeof loadConfig>>
-): string => {
+): Result<string, Error> => {
   if (cliToken) {
-    return cliToken;
+    return Result.ok(cliToken);
   }
   if (configResult.isOk()) {
-    return configResult.value.token;
+    return Result.ok(configResult.value.token);
   }
-  process.stderr.write(
-    "Error: No token found. Provide --token or set DISCORD_BOT_TOKEN.\n"
+  return Result.err(
+    new Error("No token found. Provide --token or set DISCORD_BOT_TOKEN.")
   );
-  process.exit(1);
 };
 
 export const showSettingsNonInteractive = (state: AppState): void => {

--- a/src/handlers/settings.ts
+++ b/src/handlers/settings.ts
@@ -13,7 +13,9 @@ const showCurrentSettings = (state: AppState): void => {
   log.info(`Current settings:\n${lines.join("\n")}`);
 };
 
-export const saveStateToSettings = async (state: AppState): Promise<void> => {
+export const saveStateToSettings = async (
+  state: AppState
+): Promise<Result<void, Error>> => {
   const values: { token?: string; clientId?: string; guildId?: string } = {};
   if (state.token) {
     values.token = state.token;
@@ -28,9 +30,10 @@ export const saveStateToSettings = async (state: AppState): Promise<void> => {
   const result = await saveSettings(values);
   if (result.isOk()) {
     log.success("Saved settings to ~/.discord-search/settings.json");
-  } else {
-    log.error("Failed to save settings.");
+    return Result.ok(undefined);
   }
+  log.error(`Failed to save settings: ${result.error.message}`);
+  return Result.err(result.error);
 };
 
 const handleSettingsAction = async (
@@ -177,7 +180,13 @@ export const setSettingNonInteractive = async (
     process.exit(1);
   }
 
-  await saveStateToSettings(state);
+  const result = await saveStateToSettings(state);
+  if (result.isErr()) {
+    process.stderr.write(
+      `Failed to persist setting: ${result.error.message}\n`
+    );
+    process.exit(1);
+  }
   process.stderr.write(`Updated ${key}.\n`);
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ const handleMenuAction = async (
   }
 
   if (action === "run-all") {
-    await handleRunAllPresets(state.token);
+    await handleRunAllPresets(state.token as string);
     return true;
   }
 
@@ -68,7 +68,7 @@ const handleMenuAction = async (
 
   const searchParams = await resolveSearchParams(action, state.defaultGuildId);
   if (searchParams) {
-    await executeSearch(searchParams, state.token);
+    await executeSearch(searchParams, state.token as string);
   }
 
   return true;
@@ -125,8 +125,11 @@ const handleSearchCommand = async (
   if (!cliArgs.params.guildId) {
     exitWithError("--guild is required for search.", "search");
   }
-  const token = resolveTokenNonInteractive(cliArgs.token, configResult);
-  await executeNonInteractiveSearch(cliArgs.params, token, {
+  const tokenResult = resolveTokenNonInteractive(cliArgs.token, configResult);
+  if (tokenResult.isErr()) {
+    return exitWithError(tokenResult.error.message, "search");
+  }
+  await executeNonInteractiveSearch(cliArgs.params, tokenResult.value, {
     export: cliArgs.export,
     outputDir: cliArgs.outputDir,
     json: cliArgs.json,
@@ -142,8 +145,11 @@ const handlePresetRunCommand = async (
   cliArgs: PresetRunArgs,
   configResult: ConfigResult
 ): Promise<void> => {
-  const token = resolveTokenNonInteractive(cliArgs.token, configResult);
-  await runPresetNonInteractive(cliArgs.name, token, {
+  const tokenResult = resolveTokenNonInteractive(cliArgs.token, configResult);
+  if (tokenResult.isErr()) {
+    return exitWithError(tokenResult.error.message, "preset");
+  }
+  await runPresetNonInteractive(cliArgs.name, tokenResult.value, {
     export: cliArgs.export,
     outputDir: cliArgs.outputDir,
     json: cliArgs.json,
@@ -154,11 +160,19 @@ const handlePresetRunAllCommand = async (
   cliArgs: PresetRunAllArgs,
   configResult: ConfigResult
 ): Promise<void> => {
-  const token = resolveTokenNonInteractive(cliArgs.token, configResult);
-  await runAllPresetsNonInteractive(cliArgs.names, cliArgs.all, token, {
-    export: cliArgs.export,
-    outputDir: cliArgs.outputDir,
-  });
+  const tokenResult = resolveTokenNonInteractive(cliArgs.token, configResult);
+  if (tokenResult.isErr()) {
+    return exitWithError(tokenResult.error.message, "preset");
+  }
+  await runAllPresetsNonInteractive(
+    cliArgs.names,
+    cliArgs.all,
+    tokenResult.value,
+    {
+      export: cliArgs.export,
+      outputDir: cliArgs.outputDir,
+    }
+  );
 };
 
 const handlePresetSaveCommand = async (
@@ -177,7 +191,7 @@ const buildStateFromConfig = (
   configResult: ConfigResult,
   cliToken?: string
 ): AppState => ({
-  token: configResult.isOk() ? configResult.value.token : (cliToken ?? ""),
+  token: configResult.isOk() ? configResult.value.token : cliToken,
   clientId: configResult.isOk() ? configResult.value.clientId : undefined,
   defaultGuildId: configResult.isOk()
     ? configResult.value.defaultGuildId
@@ -273,10 +287,10 @@ const main = async (): Promise<void> => {
   }
 
   if (cliArgs.version) {
-    const pkg = await Bun.file(
+    const pkg = (await Bun.file(
       new URL("../package.json", import.meta.url)
-    ).json();
-    console.log(`discord-search ${pkg.version as string}`);
+    ).json()) as { version: string };
+    console.log(`discord-search ${pkg.version}`);
     process.exit(0);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,13 @@ const handleSearchCommand = async (
   });
 
   if (cliArgs.savePreset) {
-    await savePreset(cliArgs.savePreset, cliArgs.params);
+    const saveResult = await savePreset(cliArgs.savePreset, cliArgs.params);
+    if (saveResult.isErr()) {
+      return exitWithError(
+        `Failed to save preset "${cliArgs.savePreset}": ${saveResult.error.message}`,
+        "preset"
+      );
+    }
     process.stderr.write(`Saved preset: ${cliArgs.savePreset}\n`);
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,8 @@ type ConfigResult = Awaited<ReturnType<typeof loadConfig>>;
 
 const handleMenuAction = async (
   action: string,
-  state: AppState
+  state: AppState,
+  token: string
 ): Promise<boolean> => {
   if (action === "exit") {
     return false;
@@ -57,7 +58,7 @@ const handleMenuAction = async (
   }
 
   if (action === "run-all") {
-    await handleRunAllPresets(state.token as string);
+    await handleRunAllPresets(token);
     return true;
   }
 
@@ -68,7 +69,7 @@ const handleMenuAction = async (
 
   const searchParams = await resolveSearchParams(action, state.defaultGuildId);
   if (searchParams) {
-    await executeSearch(searchParams, state.token as string);
+    await executeSearch(searchParams, token);
   }
 
   return true;
@@ -109,7 +110,11 @@ const runInteractive = async (cliArgs: ParsedArgs): Promise<void> => {
     });
     handleCancel(action);
 
-    const shouldContinue = await handleMenuAction(action as string, state);
+    const shouldContinue = await handleMenuAction(
+      action as string,
+      state,
+      token
+    );
     if (!shouldContinue) {
       break;
     }
@@ -301,4 +306,9 @@ const main = async (): Promise<void> => {
   }
 };
 
-main();
+main().catch((err: unknown) => {
+  console.error(
+    err instanceof Error ? (err.stack ?? err.message) : String(err)
+  );
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,70 +1,287 @@
 #!/usr/bin/env node
-
-import { HELP_TEXT, SUBCOMMAND_HELP } from "@/cli/args-help.ts";
+import { intro, outro, select } from "@clack/prompts";
+import { exitWithError, HELP_TEXT, SUBCOMMAND_HELP } from "@/cli/args-help.ts";
 import { parseArgs } from "@/cli/args-parse.ts";
-import type { ParsedArgs } from "@/cli/args-types.ts";
-import pkg from "../package.json";
+import type {
+  ParsedArgs,
+  PresetDeleteArgs,
+  PresetRunAllArgs,
+  PresetRunArgs,
+  PresetSaveArgs,
+  SearchArgs,
+  SettingsInviteArgs,
+  SettingsSetArgs,
+  SettingsShowArgs,
+} from "@/cli/args-types.ts";
+import { handleCancel } from "@/cli/prompts.ts";
+import { type loadConfig, loadConfig as loadConfigFn } from "@/config.ts";
+import {
+  deletePresetNonInteractive,
+  handleManagePresets,
+  handleRunAllPresets,
+  listPresetsNonInteractive,
+  resolveSearchParams,
+  runAllPresetsNonInteractive,
+  runPresetNonInteractive,
+  savePresetNonInteractive,
+} from "@/handlers/presets.ts";
+import {
+  executeNonInteractiveSearch,
+  executeSearch,
+} from "@/handlers/search.ts";
+import {
+  handleSettings,
+  resolveToken,
+  resolveTokenNonInteractive,
+  setSettingNonInteractive,
+  showInviteLinkNonInteractive,
+  showSettingsNonInteractive,
+} from "@/handlers/settings.ts";
+import { ensureAppDir } from "@/paths.ts";
+import { savePreset } from "@/presets.ts";
+import type { AppState } from "@/types.ts";
 
-const VERSION = pkg.version;
+type ConfigResult = Awaited<ReturnType<typeof loadConfig>>;
 
-const printHelp = (parsed: ParsedArgs & { command: "help" }) => {
-  const target = parsed.targetCommand;
-  const helpText = target ? SUBCOMMAND_HELP[target] : HELP_TEXT;
-  process.stdout.write(`${helpText}\n`);
+const handleMenuAction = async (
+  action: string,
+  state: AppState
+): Promise<boolean> => {
+  if (action === "exit") {
+    return false;
+  }
+
+  if (action === "manage") {
+    await handleManagePresets();
+    return true;
+  }
+
+  if (action === "run-all") {
+    await handleRunAllPresets(state.token);
+    return true;
+  }
+
+  if (action === "settings") {
+    await handleSettings(state);
+    return true;
+  }
+
+  const searchParams = await resolveSearchParams(action, state.defaultGuildId);
+  if (searchParams) {
+    await executeSearch(searchParams, state.token);
+  }
+
+  return true;
 };
 
-const printVersion = () => {
-  process.stdout.write(`discord-search ${VERSION}\n`);
+const runInteractive = async (cliArgs: ParsedArgs): Promise<void> => {
+  if (cliArgs.command !== "interactive") {
+    return;
+  }
+
+  intro("Discord Search");
+
+  await ensureAppDir();
+  const configResult = await loadConfigFn();
+  const token = await resolveToken(cliArgs.token, configResult);
+
+  const state: AppState = {
+    token,
+    clientId:
+      cliArgs.clientId ??
+      (configResult.isOk() ? configResult.value.clientId : undefined),
+    defaultGuildId:
+      cliArgs.guild ??
+      (configResult.isOk() ? configResult.value.defaultGuildId : undefined),
+  };
+
+  while (true) {
+    const action = await select({
+      message: "What would you like to do?",
+      options: [
+        { value: "search", label: "New search" },
+        { value: "preset", label: "Load preset" },
+        { value: "run-all", label: "Bulk run presets" },
+        { value: "manage", label: "Manage presets" },
+        { value: "settings", label: "Settings" },
+        { value: "exit", label: "Exit" },
+      ],
+    });
+    handleCancel(action);
+
+    const shouldContinue = await handleMenuAction(action as string, state);
+    if (!shouldContinue) {
+      break;
+    }
+  }
+
+  outro("Goodbye!");
 };
 
-const run = () => {
-  const parsed = parseArgs(process.argv.slice(2));
-
-  if (parsed.version) {
-    printVersion();
-    process.exitCode = 0;
-    return;
+const handleSearchCommand = async (
+  cliArgs: SearchArgs,
+  configResult: ConfigResult
+): Promise<void> => {
+  if (!cliArgs.params.guildId) {
+    exitWithError("--guild is required for search.", "search");
   }
+  const token = resolveTokenNonInteractive(cliArgs.token, configResult);
+  await executeNonInteractiveSearch(cliArgs.params, token, {
+    export: cliArgs.export,
+    outputDir: cliArgs.outputDir,
+    json: cliArgs.json,
+  });
 
-  if (parsed.command === "help") {
-    printHelp(parsed);
-    process.exitCode = 0;
-    return;
+  if (cliArgs.savePreset) {
+    await savePreset(cliArgs.savePreset, cliArgs.params);
+    process.stderr.write(`Saved preset: ${cliArgs.savePreset}\n`);
   }
-
-  if (parsed.command === "interactive") {
-    process.stderr.write(
-      "Interactive mode is not yet implemented. Use 'discord-search search --help' for CLI usage.\n"
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  if (parsed.command === "search") {
-    process.stderr.write("Search command execution is not yet implemented.\n");
-    process.exitCode = 1;
-    return;
-  }
-
-  if (parsed.command === "preset") {
-    process.stderr.write("Preset command execution is not yet implemented.\n");
-    process.exitCode = 1;
-    return;
-  }
-
-  if (parsed.command === "settings") {
-    process.stderr.write(
-      "Settings command execution is not yet implemented.\n"
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  const _exhaustive: never = parsed;
-  process.stderr.write(
-    `Unhandled command: ${(_exhaustive as ParsedArgs).command}\n`
-  );
-  process.exitCode = 1;
 };
 
-run();
+const handlePresetRunCommand = async (
+  cliArgs: PresetRunArgs,
+  configResult: ConfigResult
+): Promise<void> => {
+  const token = resolveTokenNonInteractive(cliArgs.token, configResult);
+  await runPresetNonInteractive(cliArgs.name, token, {
+    export: cliArgs.export,
+    outputDir: cliArgs.outputDir,
+    json: cliArgs.json,
+  });
+};
+
+const handlePresetRunAllCommand = async (
+  cliArgs: PresetRunAllArgs,
+  configResult: ConfigResult
+): Promise<void> => {
+  const token = resolveTokenNonInteractive(cliArgs.token, configResult);
+  await runAllPresetsNonInteractive(cliArgs.names, cliArgs.all, token, {
+    export: cliArgs.export,
+    outputDir: cliArgs.outputDir,
+  });
+};
+
+const handlePresetSaveCommand = async (
+  cliArgs: PresetSaveArgs
+): Promise<void> => {
+  await savePresetNonInteractive(cliArgs.name, cliArgs.params);
+};
+
+const handlePresetDeleteCommand = async (
+  cliArgs: PresetDeleteArgs
+): Promise<void> => {
+  await deletePresetNonInteractive(cliArgs.name);
+};
+
+const buildStateFromConfig = (
+  configResult: ConfigResult,
+  cliToken?: string
+): AppState => ({
+  token: configResult.isOk() ? configResult.value.token : (cliToken ?? ""),
+  clientId: configResult.isOk() ? configResult.value.clientId : undefined,
+  defaultGuildId: configResult.isOk()
+    ? configResult.value.defaultGuildId
+    : undefined,
+});
+
+const handleSettingsShowCommand = (
+  cliArgs: SettingsShowArgs,
+  configResult: ConfigResult
+): void => {
+  showSettingsNonInteractive(buildStateFromConfig(configResult, cliArgs.token));
+};
+
+const handleSettingsSetCommand = async (
+  cliArgs: SettingsSetArgs,
+  configResult: ConfigResult
+): Promise<void> => {
+  const state = buildStateFromConfig(configResult, cliArgs.token);
+  await setSettingNonInteractive(cliArgs.key, cliArgs.value, state);
+};
+
+const handleSettingsInviteCommand = (
+  cliArgs: SettingsInviteArgs,
+  configResult: ConfigResult
+): void => {
+  const clientId =
+    cliArgs.clientId ??
+    (configResult.isOk() ? configResult.value.clientId : undefined);
+  showInviteLinkNonInteractive(clientId);
+};
+
+const handlePresetCommand = async (
+  cliArgs: ParsedArgs,
+  configResult: ConfigResult
+): Promise<void> => {
+  if (cliArgs.command !== "preset") {
+    return;
+  }
+
+  if (cliArgs.action === "list") {
+    await listPresetsNonInteractive();
+  } else if (cliArgs.action === "run") {
+    await handlePresetRunCommand(cliArgs, configResult);
+  } else if (cliArgs.action === "run-all") {
+    await handlePresetRunAllCommand(cliArgs, configResult);
+  } else if (cliArgs.action === "save") {
+    await handlePresetSaveCommand(cliArgs);
+  } else if (cliArgs.action === "delete") {
+    await handlePresetDeleteCommand(cliArgs);
+  }
+};
+
+const handleSettingsCommand = async (
+  cliArgs: ParsedArgs,
+  configResult: ConfigResult
+): Promise<void> => {
+  if (cliArgs.command !== "settings") {
+    return;
+  }
+
+  if (cliArgs.action === "show") {
+    handleSettingsShowCommand(cliArgs, configResult);
+  } else if (cliArgs.action === "set") {
+    await handleSettingsSetCommand(cliArgs, configResult);
+  } else if (cliArgs.action === "invite") {
+    handleSettingsInviteCommand(cliArgs, configResult);
+  }
+};
+
+const runNonInteractive = async (cliArgs: ParsedArgs): Promise<void> => {
+  await ensureAppDir();
+  const configResult = await loadConfigFn();
+
+  if (cliArgs.command === "search") {
+    await handleSearchCommand(cliArgs, configResult);
+  } else if (cliArgs.command === "preset") {
+    await handlePresetCommand(cliArgs, configResult);
+  } else if (cliArgs.command === "settings") {
+    await handleSettingsCommand(cliArgs, configResult);
+  }
+};
+
+const main = async (): Promise<void> => {
+  const cliArgs = parseArgs(process.argv.slice(2));
+
+  if (cliArgs.help) {
+    const subHelp = SUBCOMMAND_HELP[cliArgs.command];
+    console.log(subHelp ?? HELP_TEXT);
+    process.exit(0);
+  }
+
+  if (cliArgs.version) {
+    const pkg = await Bun.file(
+      new URL("../package.json", import.meta.url)
+    ).json();
+    console.log(`discord-search ${pkg.version as string}`);
+    process.exit(0);
+  }
+
+  if (cliArgs.command === "interactive") {
+    await runInteractive(cliArgs);
+  } else {
+    await runNonInteractive(cliArgs);
+  }
+};
+
+main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,10 @@ const main = async (): Promise<void> => {
   const cliArgs = parseArgs(process.argv.slice(2));
 
   if (cliArgs.help) {
-    const subHelp = SUBCOMMAND_HELP[cliArgs.command];
+    const subHelp =
+      cliArgs.command in SUBCOMMAND_HELP
+        ? SUBCOMMAND_HELP[cliArgs.command as keyof typeof SUBCOMMAND_HELP]
+        : undefined;
     console.log(subHelp ?? HELP_TEXT);
     process.exit(0);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { intro, outro, select } from "@clack/prompts";
+import { intro, log, outro, select } from "@clack/prompts";
 import { exitWithError, HELP_TEXT, SUBCOMMAND_HELP } from "@/cli/args-help.ts";
 import { parseArgs } from "@/cli/args-parse.ts";
 import type {
@@ -45,8 +45,7 @@ type ConfigResult = Awaited<ReturnType<typeof loadConfig>>;
 
 const handleMenuAction = async (
   action: string,
-  state: AppState,
-  token: string
+  state: AppState
 ): Promise<boolean> => {
   if (action === "exit") {
     return false;
@@ -58,7 +57,11 @@ const handleMenuAction = async (
   }
 
   if (action === "run-all") {
-    await handleRunAllPresets(token);
+    if (!state.token) {
+      log.error("No token configured. Update your token in Settings first.");
+      return true;
+    }
+    await handleRunAllPresets(state.token);
     return true;
   }
 
@@ -67,9 +70,13 @@ const handleMenuAction = async (
     return true;
   }
 
+  if (!state.token) {
+    log.error("No token configured. Update your token in Settings first.");
+    return true;
+  }
   const searchParams = await resolveSearchParams(action, state.defaultGuildId);
   if (searchParams) {
-    await executeSearch(searchParams, token);
+    await executeSearch(searchParams, state.token);
   }
 
   return true;
@@ -110,11 +117,7 @@ const runInteractive = async (cliArgs: ParsedArgs): Promise<void> => {
     });
     handleCancel(action);
 
-    const shouldContinue = await handleMenuAction(
-      action as string,
-      state,
-      token
-    );
+    const shouldContinue = await handleMenuAction(action as string, state);
     if (!shouldContinue) {
       break;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type AppState = {
-  token: string;
+  token: string | undefined;
   clientId: string | undefined;
   defaultGuildId: string | undefined;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import type { Config } from "@/config.ts";
-
 export type AppState = {
-  config: Config;
+  token: string;
+  clientId: string | undefined;
+  defaultGuildId: string | undefined;
 };


### PR DESCRIPTION
## Summary
- Add search handler with live view toggle and post-search menu (browse, export)
- Add preset handler for CRUD operations and bulk run with sequential execution
- Add settings handler for token/client-id/guild management and invite link generation
- Add export handler for interactive and non-interactive format selection
- Add main entry point wiring interactive menu loop and non-interactive CLI dispatch

## Stacked PR Chain
This is **PR 7 of 7** — merge in order.
`main` ← PR1 ← PR2 ← PR3 ← PR4 ← PR5 ← PR6 ← **PR7**

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run check` passes linting
- [ ] `bun run build` produces working binary
- [ ] Interactive mode launches menu correctly
- [ ] Non-interactive `search` command executes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds search, preset, settings, and export handlers plus the CLI entry point. Supports interactive and non-interactive flows for running searches, browsing results, exporting JSON/CSVs, and managing presets/settings.

- **New Features**
  - Interactive search with live JSON toggle (v), progress, summary, and actions to browse (j/k, v) or export.
  - Presets: save/load/delete; select multiple and run sequentially; non-interactive list/run/run-all/save/delete; `preset run` supports `--json`; export dirs use sanitized preset names.
  - Settings: update token, client ID, and default guild; generate invite link; persists to ~/.discord-search/settings.json.
  - Export: JSON and CSV (messages, embeds, fields) with custom output dir; CLI `--export` supports `json`, `csv-messages`, `csv-embeds`, `csv-fields`, or `all`.
  - CLI: `interactive` menu and subcommands `search` (supports `--json`, `--save-preset`), `preset` (list/run/run-all/save/delete), `settings` (show/set/invite); progress streamed to stderr.

- **Bug Fixes**
  - Validate export format and Result outcomes; mkdir before preset export; sanitize export dir names; in bulk runs, log export errors and continue to next preset.
  - Reject `--json` for `preset run-all` (use `--export`); use `collateResults([])` for zero-result JSON; separate load-error handling in bulk runs to surface failures clearly.
  - Return `Result` from non-interactive token resolution; remove unsafe token casts; make `AppState.token` explicitly undefined when missing.
  - Replace hardcoded output paths with `OUTPUT_DIR`; type the `package.json` version read; fix types for `AppState`, progress callbacks, and `SUBCOMMAND_HELP`; handle top-level `main()` rejections; switch typecheck to `tsgo`.

<sup>Written for commit 90d81a3e0cbd72a7f66b066bdcca54aa3d114bf2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

