### PR TITLE
feat: add core types, error definitions, and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ opensrc/
 
 # Presets
 .discord-search-presets.json
+
+# Traycer
+.traycer/

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ coverage
 # logs
 logs
 *.log
-report*.json
+report.*.json
 
 # dotenv environment variable files
 .env

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -9,6 +9,9 @@
   },
   "linter": {
     "rules": {
+      "suspicious": {
+        "noBitwiseOperators": "off"
+      },
       "style": {
         "useConsistentTypeDefinitions": {
           "level": "error",

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,7 @@ export type Config = {
   token: string;
 };
 
-type SettingsJson = {
+export type SettingsJson = {
   token?: string;
   guildId?: string;
   clientId?: string;
@@ -50,27 +50,7 @@ const readSettingsFile = async (): Promise<SettingsJson> => {
 };
 
 export const loadConfig = async (): Promise<Result<Config, ConfigError>> => {
-  let settings: SettingsJson = {};
-  try {
-    settings = await readSettingsFile();
-  } catch (err) {
-    // Only swallow ENOENT (file missing)
-    if (
-      err &&
-      typeof err === "object" &&
-      "code" in err &&
-      err.code === "ENOENT"
-    ) {
-      // File missing is OK - fall through to env vars
-    } else {
-      // Other errors (permission, disk, etc.) are real failures
-      return new Err(
-        new ConfigError({
-          message: `Failed to read settings: ${err instanceof Error ? err.message : String(err)}`,
-        })
-      );
-    }
-  }
+  const settings = await readSettingsFile();
 
   const token = process.env.DISCORD_BOT_TOKEN ?? settings.token;
 
@@ -107,23 +87,7 @@ export const saveSettings = async (
 
     await ensureAppDir();
 
-    let existing: SettingsJson = {};
-    try {
-      existing = await readSettingsFile();
-    } catch (err) {
-      // Only swallow ENOENT (file missing)
-      if (
-        err &&
-        typeof err === "object" &&
-        "code" in err &&
-        err.code === "ENOENT"
-      ) {
-        // File missing is OK - fall through with existing = {}
-      } else {
-        // Other errors (permission, disk, etc.) are real failures
-        throw err;
-      }
-    }
+    const existing = await readSettingsFile();
 
     const merged = { ...existing, ...validationResult.data };
 
@@ -161,7 +125,15 @@ export const saveSettings = async (
   }
 };
 
-const BOT_PERMISSIONS = 66_560; // VIEW_CHANNEL (1024) + READ_MESSAGE_HISTORY (65536)
+const BOT_PERMISSION_FLAGS = {
+  VIEW_CHANNEL: 1024,
+  READ_MESSAGE_HISTORY: 65_536,
+} as const;
+
+const BOT_PERMISSIONS = Object.values(BOT_PERMISSION_FLAGS).reduce(
+  (a, b) => a + b,
+  0
+);
 
 export const generateInviteLink = (clientId: string): string =>
-  `https://discord.com/oauth2/authorize?client_id=${clientId}&scope=bot&permissions=${BOT_PERMISSIONS}`;
+  `https://discord.com/oauth2/authorize?client_id=${encodeURIComponent(clientId)}&scope=bot&permissions=${BOT_PERMISSIONS}`;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,82 @@
+import { Err, Ok, type Result } from "better-result";
+import { ConfigError, ExportError } from "@/errors.ts";
+import { ensureAppDir, SETTINGS_FILE } from "@/paths.ts";
+
+export type Config = {
+  clientId: string | undefined;
+  defaultGuildId: string | undefined;
+  token: string;
+};
+
+type SettingsJson = {
+  token?: string;
+  guildId?: string;
+  clientId?: string;
+};
+
+const readSettingsFile = async (): Promise<SettingsJson> => {
+  const file = Bun.file(SETTINGS_FILE);
+  if (!(await file.exists())) {
+    return {};
+  }
+  const text = await file.text();
+  return JSON.parse(text) as SettingsJson;
+};
+
+export const loadConfig = async (): Promise<Result<Config, ConfigError>> => {
+  let settings: SettingsJson = {};
+  try {
+    settings = await readSettingsFile();
+  } catch {
+    // Settings file missing or invalid — fall through to env vars
+  }
+
+  const token = process.env.DISCORD_BOT_TOKEN ?? settings.token;
+
+  if (!token) {
+    return new Err(
+      new ConfigError({
+        message:
+          "DISCORD_BOT_TOKEN is not set. Set it via environment variable or run the app to save settings to ~/.discord-search/settings.json.",
+      })
+    );
+  }
+
+  return new Ok({
+    token,
+    defaultGuildId: process.env.DISCORD_GUILD_ID ?? settings.guildId,
+    clientId: process.env.DISCORD_CLIENT_ID ?? settings.clientId,
+  });
+};
+
+export const saveSettings = async (
+  values: SettingsJson
+): Promise<Result<void, ExportError>> => {
+  try {
+    await ensureAppDir();
+
+    let existing: SettingsJson = {};
+    try {
+      existing = await readSettingsFile();
+    } catch {
+      // Start fresh if file is missing or corrupt
+    }
+
+    const merged = { ...existing, ...values };
+
+    await Bun.write(SETTINGS_FILE, `${JSON.stringify(merged, null, 2)}\n`);
+    return new Ok(undefined);
+  } catch (cause) {
+    return new Err(
+      new ExportError({
+        message: `Failed to save settings: ${cause instanceof Error ? cause.message : String(cause)}`,
+        cause,
+      })
+    );
+  }
+};
+
+const BOT_PERMISSIONS = 66_560; // VIEW_CHANNEL (1024) + READ_MESSAGE_HISTORY (65536)
+
+export const generateInviteLink = (clientId: string): string =>
+  `https://discord.com/oauth2/authorize?client_id=${clientId}&scope=bot&permissions=${BOT_PERMISSIONS}`;

--- a/src/config.ts
+++ b/src/config.ts
@@ -111,13 +111,16 @@ export const saveSettings = async (
     try {
       existing = await readSettingsFile();
     } catch (err) {
-      // Only swallow ENOENT
+      // Only swallow ENOENT (file missing)
       if (
         err &&
         typeof err === "object" &&
         "code" in err &&
-        err.code !== "ENOENT"
+        err.code === "ENOENT"
       ) {
+        // File missing is OK - fall through with existing = {}
+      } else {
+        // Other errors (permission, disk, etc.) are real failures
         throw err;
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -129,8 +129,22 @@ export const saveSettings = async (
     // Secure file permissions (owner-only)
     try {
       await chmod(SETTINGS_FILE, 0o600);
-    } catch {
-      // chmod may fail on some systems
+    } catch (err) {
+      // Only ignore known unsupported cases (e.g., Windows)
+      if (
+        err &&
+        typeof err === "object" &&
+        "code" in err &&
+        err.code !== "ENOTSUP" &&
+        err.code !== "EINVAL"
+      ) {
+        return new Err(
+          new ExportError({
+            message: `Failed to secure settings file permissions: ${err instanceof Error ? err.message : String(err)}`,
+            cause: err,
+          })
+        );
+      }
     }
 
     return new Ok(undefined);

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,11 +16,7 @@ export type Config = {
   token: string;
 };
 
-export type SettingsJson = {
-  token?: string;
-  guildId?: string;
-  clientId?: string;
-};
+export type SettingsJson = z.infer<typeof SettingsSchema>;
 
 const readSettingsFile = async (): Promise<SettingsJson> => {
   const file = Bun.file(SETTINGS_FILE);
@@ -50,7 +46,16 @@ const readSettingsFile = async (): Promise<SettingsJson> => {
 };
 
 export const loadConfig = async (): Promise<Result<Config, ConfigError>> => {
-  const settings = await readSettingsFile();
+  let settings: SettingsJson;
+  try {
+    settings = await readSettingsFile();
+  } catch (err) {
+    return new Err(
+      new ConfigError({
+        message: `Failed to read settings: ${err instanceof Error ? err.message : String(err)}`,
+      })
+    );
+  }
 
   const token = process.env.DISCORD_BOT_TOKEN ?? settings.token;
 
@@ -97,14 +102,14 @@ export const saveSettings = async (
     try {
       await chmod(SETTINGS_FILE, 0o600);
     } catch (err) {
-      // Only ignore known unsupported cases (e.g., Windows)
       if (
         err &&
         typeof err === "object" &&
         "code" in err &&
-        err.code !== "ENOTSUP" &&
-        err.code !== "EINVAL"
+        (err.code === "ENOTSUP" || err.code === "EINVAL")
       ) {
+        // Ignore known unsupported cases (e.g., Windows)
+      } else {
         return new Err(
           new ExportError({
             message: `Failed to secure settings file permissions: ${err instanceof Error ? err.message : String(err)}`,
@@ -131,7 +136,7 @@ const BOT_PERMISSION_FLAGS = {
 } as const;
 
 const BOT_PERMISSIONS = Object.values(BOT_PERMISSION_FLAGS).reduce(
-  (a, b) => a + b,
+  (a, b) => a | b,
   0
 );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,14 @@
+import { chmod } from "node:fs/promises";
 import { Err, Ok, type Result } from "better-result";
+import { z } from "zod";
 import { ConfigError, ExportError } from "@/errors.ts";
 import { ensureAppDir, SETTINGS_FILE } from "@/paths.ts";
+
+const SettingsSchema = z.object({
+  token: z.string().optional(),
+  guildId: z.string().optional(),
+  clientId: z.string().optional(),
+});
 
 export type Config = {
   clientId: string | undefined;
@@ -19,16 +27,49 @@ const readSettingsFile = async (): Promise<SettingsJson> => {
   if (!(await file.exists())) {
     return {};
   }
-  const text = await file.text();
-  return JSON.parse(text) as SettingsJson;
+  try {
+    const text = await file.text();
+    const parsed = JSON.parse(text);
+
+    // Validate with Zod
+    const result = SettingsSchema.safeParse(parsed);
+    if (!result.success) {
+      // Invalid format but recoverable - return empty
+      return {};
+    }
+
+    return result.data;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      // Invalid JSON but recoverable
+      return {};
+    }
+    // Re-throw I/O errors for caller to handle
+    throw err;
+  }
 };
 
 export const loadConfig = async (): Promise<Result<Config, ConfigError>> => {
   let settings: SettingsJson = {};
   try {
     settings = await readSettingsFile();
-  } catch {
-    // Settings file missing or invalid — fall through to env vars
+  } catch (err) {
+    // Only swallow ENOENT (file missing)
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      err.code === "ENOENT"
+    ) {
+      // File missing is OK - fall through to env vars
+    } else {
+      // Other errors (permission, disk, etc.) are real failures
+      return new Err(
+        new ConfigError({
+          message: `Failed to read settings: ${err instanceof Error ? err.message : String(err)}`,
+        })
+      );
+    }
   }
 
   const token = process.env.DISCORD_BOT_TOKEN ?? settings.token;
@@ -53,18 +94,45 @@ export const saveSettings = async (
   values: SettingsJson
 ): Promise<Result<void, ExportError>> => {
   try {
+    // Validate input before processing
+    const validationResult = SettingsSchema.safeParse(values);
+    if (!validationResult.success) {
+      return new Err(
+        new ExportError({
+          message: `Invalid settings data: ${validationResult.error.message}`,
+          cause: new Error(validationResult.error.message),
+        })
+      );
+    }
+
     await ensureAppDir();
 
     let existing: SettingsJson = {};
     try {
       existing = await readSettingsFile();
-    } catch {
-      // Start fresh if file is missing or corrupt
+    } catch (err) {
+      // Only swallow ENOENT
+      if (
+        err &&
+        typeof err === "object" &&
+        "code" in err &&
+        err.code !== "ENOENT"
+      ) {
+        throw err;
+      }
     }
 
-    const merged = { ...existing, ...values };
+    const merged = { ...existing, ...validationResult.data };
 
     await Bun.write(SETTINGS_FILE, `${JSON.stringify(merged, null, 2)}\n`);
+
+    // Secure file permissions (owner-only)
+    try {
+      await chmod(SETTINGS_FILE, 0o600);
+    } catch {
+      // chmod may fail on some systems
+    }
+
     return new Ok(undefined);
   } catch (cause) {
     return new Err(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,33 @@
+import { TaggedError } from "better-result";
+
+export class ConfigError extends TaggedError("ConfigError")<{
+  message: string;
+}>() {}
+
+export class DiscordApiError extends TaggedError("DiscordApiError")<{
+  message: string;
+  status: number;
+  body: unknown;
+}>() {}
+
+export class RateLimitExhaustedError extends TaggedError(
+  "RateLimitExhaustedError"
+)<{
+  message: string;
+  retryAfter: number;
+}>() {}
+
+export class IndexNotReadyError extends TaggedError("IndexNotReadyError")<{
+  message: string;
+  retryAfter: number;
+}>() {}
+
+export class ValidationError extends TaggedError("ValidationError")<{
+  message: string;
+  issues: unknown;
+}>() {}
+
+export class ExportError extends TaggedError("ExportError")<{
+  message: string;
+  cause: unknown;
+}>() {}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,5 @@
 import { TaggedError } from "better-result";
+import type { ZodIssue } from "zod";
 
 export class ConfigError extends TaggedError("ConfigError")<{
   message: string;
@@ -24,7 +25,7 @@ export class IndexNotReadyError extends TaggedError("IndexNotReadyError")<{
 
 export class ValidationError extends TaggedError("ValidationError")<{
   message: string;
-  issues: unknown;
+  issues: ZodIssue[];
 }>() {}
 
 export class ExportError extends TaggedError("ExportError")<{

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,17 @@
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const APP_DIR = join(homedir(), ".discord-search");
+export const SETTINGS_FILE = join(APP_DIR, "settings.json");
+export const OUTPUT_DIR = join(APP_DIR, "output");
+
+export const ensureAppDir = async (): Promise<void> => {
+  await mkdir(APP_DIR, { recursive: true });
+
+  const gitignorePath = join(APP_DIR, ".gitignore");
+  const file = Bun.file(gitignorePath);
+  if (!(await file.exists())) {
+    await Bun.write(gitignorePath, "*\n");
+  }
+};

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -14,9 +14,10 @@ const chmodSafe = async (path: string, mode: number): Promise<void> => {
       err &&
       typeof err === "object" &&
       "code" in err &&
-      err.code !== "ENOTSUP" &&
-      err.code !== "EINVAL"
+      (err.code === "ENOTSUP" || err.code === "EINVAL")
     ) {
+      // Ignore known unsupported cases (e.g., Windows)
+    } else {
       throw err;
     }
   }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -6,44 +6,28 @@ export const APP_DIR = join(homedir(), ".discord-search");
 export const SETTINGS_FILE = join(APP_DIR, "settings.json");
 export const OUTPUT_DIR = join(APP_DIR, "output");
 
+const chmodSafe = async (path: string, mode: number): Promise<void> => {
+  try {
+    await chmod(path, mode);
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      err.code !== "ENOTSUP" &&
+      err.code !== "EINVAL"
+    ) {
+      throw err;
+    }
+  }
+};
+
 export const ensureAppDir = async (): Promise<void> => {
-  // Create APP_DIR with owner-only permissions
   await mkdir(APP_DIR, { recursive: true, mode: 0o700 });
+  await chmodSafe(APP_DIR, 0o700);
 
-  // Ensure permissions are correct (in case directory existed)
-  try {
-    await chmod(APP_DIR, 0o700);
-  } catch (err) {
-    // Only ignore known unsupported cases (e.g., Windows)
-    if (
-      err &&
-      typeof err === "object" &&
-      "code" in err &&
-      err.code !== "ENOTSUP" &&
-      err.code !== "EINVAL"
-    ) {
-      throw err;
-    }
-  }
-
-  // Create OUTPUT_DIR with owner-only permissions
   await mkdir(OUTPUT_DIR, { recursive: true, mode: 0o700 });
-
-  // Ensure OUTPUT_DIR permissions are correct
-  try {
-    await chmod(OUTPUT_DIR, 0o700);
-  } catch (err) {
-    // Only ignore known unsupported cases (e.g., Windows)
-    if (
-      err &&
-      typeof err === "object" &&
-      "code" in err &&
-      err.code !== "ENOTSUP" &&
-      err.code !== "EINVAL"
-    ) {
-      throw err;
-    }
-  }
+  await chmodSafe(OUTPUT_DIR, 0o700);
 
   const gitignorePath = join(APP_DIR, ".gitignore");
   const file = Bun.file(gitignorePath);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,4 +1,4 @@
-import { mkdir } from "node:fs/promises";
+import { chmod, mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -7,7 +7,25 @@ export const SETTINGS_FILE = join(APP_DIR, "settings.json");
 export const OUTPUT_DIR = join(APP_DIR, "output");
 
 export const ensureAppDir = async (): Promise<void> => {
-  await mkdir(APP_DIR, { recursive: true });
+  // Create APP_DIR with owner-only permissions
+  await mkdir(APP_DIR, { recursive: true, mode: 0o700 });
+
+  // Ensure permissions are correct (in case directory existed)
+  try {
+    await chmod(APP_DIR, 0o700);
+  } catch {
+    // chmod may fail on some systems, but mkdir already set mode
+  }
+
+  // Create OUTPUT_DIR with owner-only permissions
+  await mkdir(OUTPUT_DIR, { recursive: true, mode: 0o700 });
+
+  // Ensure OUTPUT_DIR permissions are correct
+  try {
+    await chmod(OUTPUT_DIR, 0o700);
+  } catch {
+    // chmod may fail on some systems, but mkdir already set mode
+  }
 
   const gitignorePath = join(APP_DIR, ".gitignore");
   const file = Bun.file(gitignorePath);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -13,8 +13,17 @@ export const ensureAppDir = async (): Promise<void> => {
   // Ensure permissions are correct (in case directory existed)
   try {
     await chmod(APP_DIR, 0o700);
-  } catch {
-    // chmod may fail on some systems, but mkdir already set mode
+  } catch (err) {
+    // Only ignore known unsupported cases (e.g., Windows)
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      err.code !== "ENOTSUP" &&
+      err.code !== "EINVAL"
+    ) {
+      throw err;
+    }
   }
 
   // Create OUTPUT_DIR with owner-only permissions
@@ -23,8 +32,17 @@ export const ensureAppDir = async (): Promise<void> => {
   // Ensure OUTPUT_DIR permissions are correct
   try {
     await chmod(OUTPUT_DIR, 0o700);
-  } catch {
-    // chmod may fail on some systems, but mkdir already set mode
+  } catch (err) {
+    // Only ignore known unsupported cases (e.g., Windows)
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      err.code !== "ENOTSUP" &&
+      err.code !== "EINVAL"
+    ) {
+      throw err;
+    }
   }
 
   const gitignorePath = join(APP_DIR, ".gitignore");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+import type { Config } from "@/config.ts";
+
+export type AppState = {
+  config: Config;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,0 @@
-export type AppState = {
-  clientId: string | undefined;
-  defaultGuildId: string | undefined;
-  token: string;
-};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+export type AppState = {
+  clientId: string | undefined;
+  defaultGuildId: string | undefined;
+  token: string;
+};


### PR DESCRIPTION
## Summary
- Cherry-picked all PR #2 commits onto a clean branch based on `main`
- Adds `AppState` type for application state management
- Adds tagged error classes using `better-result` for railway-oriented error handling
- Adds app directory paths (`~/.discord-search`)
- Adds settings file I/O with Zod validation

## Context
PR #2 (`init/02-core-types`) was accidentally merged with PR #1 commits mixed in, then reverted. This PR brings over only the PR #2-specific commits cleanly onto `main`.

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run check` passes linting