### PR TITLE
feat: support .jsonc preset files

### DIFF
--- a/.changeset/silver-mango-tornado.md
+++ b/.changeset/silver-mango-tornado.md
@@ -1,0 +1,5 @@
+---
+"discord-search": minor
+---
+
+Add support for `.jsonc` preset files. If a `.jsonc` preset file exists it takes priority over `.json`. Comments (`//` and `/* */`) are stripped before parsing so users can annotate their presets.

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -5,7 +5,16 @@ import { join } from "node:path";
 export const APP_DIR = join(homedir(), ".discord-search");
 export const SETTINGS_FILE = join(APP_DIR, "settings.json");
 export const PRESETS_FILE = join(APP_DIR, ".discord-search-presets.json");
+export const PRESETS_FILE_JSONC = join(
+  APP_DIR,
+  ".discord-search-presets.jsonc"
+);
 export const OUTPUT_DIR = join(APP_DIR, "output");
+
+export const getPresetsFile = async (): Promise<string> => {
+  const jsoncFile = Bun.file(PRESETS_FILE_JSONC);
+  return (await jsoncFile.exists()) ? PRESETS_FILE_JSONC : PRESETS_FILE;
+};
 
 const chmodSafe = async (path: string, mode: number): Promise<void> => {
   try {

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -2,7 +2,7 @@ import { Result } from "better-result";
 import { z } from "zod";
 import { SearchParamsSchema } from "@/discord/schemas.ts";
 import { PresetError } from "@/errors.ts";
-import { PRESETS_FILE } from "@/paths.ts";
+import { getPresetsFile } from "@/paths.ts";
 
 const PresetSchema = z.object({
   name: z.string(),
@@ -13,16 +13,80 @@ const PresetsArraySchema = z.array(PresetSchema);
 
 export type Preset = z.infer<typeof PresetSchema>;
 
+const consumeStringChars = (
+  text: string,
+  start: number,
+  out: string[]
+): number => {
+  let i = start;
+  while (i < text.length) {
+    const ch = text.charAt(i);
+    if (ch === "\\") {
+      out.push(ch, text.charAt(i + 1));
+      i += 2;
+    } else if (ch === '"') {
+      out.push(ch);
+      return i + 1;
+    } else {
+      out.push(ch);
+      i++;
+    }
+  }
+  return i;
+};
+
+const skipComment = (text: string, start: number): number => {
+  if (text.charAt(start + 1) === "/") {
+    let i = start;
+    while (i < text.length && text.charAt(i) !== "\n") {
+      i++;
+    }
+    return i;
+  }
+  let i = start + 2;
+  while (
+    i < text.length &&
+    !(text.charAt(i) === "*" && text.charAt(i + 1) === "/")
+  ) {
+    i++;
+  }
+  return i + 2;
+};
+
+const parseJsonc = (text: string): unknown => {
+  const out: string[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const ch = text.charAt(i);
+    if (ch === '"') {
+      out.push(ch);
+      i = consumeStringChars(text, i + 1, out);
+    } else if (
+      ch === "/" &&
+      (text.charAt(i + 1) === "/" || text.charAt(i + 1) === "*")
+    ) {
+      i = skipComment(text, i);
+    } else {
+      out.push(ch);
+      i++;
+    }
+  }
+  return JSON.parse(out.join(""));
+};
+
 export const loadPresets = async (): Promise<Result<Preset[], PresetError>> => {
   return await Result.tryPromise({
     try: async () => {
-      const file = Bun.file(PRESETS_FILE);
+      const presetsFile = await getPresetsFile();
+      const file = Bun.file(presetsFile);
       const exists = await file.exists();
       if (!exists) {
         return [];
       }
       const text = await file.text();
-      const parsed = JSON.parse(text);
+      const parsed = presetsFile.endsWith(".jsonc")
+        ? parseJsonc(text)
+        : JSON.parse(text);
       return PresetsArraySchema.parse(parsed);
     },
     catch: (cause) =>
@@ -52,7 +116,8 @@ export const savePreset = async (
         presets.push({ name, params });
       }
 
-      await Bun.write(PRESETS_FILE, JSON.stringify(presets, null, 2));
+      const presetsFile = await getPresetsFile();
+      await Bun.write(presetsFile, JSON.stringify(presets, null, 2));
     },
     catch: (cause) =>
       new PresetError({
@@ -73,7 +138,8 @@ export const deletePreset = async (
       }
       const presets = presetsResult.value;
       const filtered = presets.filter((p) => p.name !== name);
-      await Bun.write(PRESETS_FILE, JSON.stringify(filtered, null, 2));
+      const presetsFile = await getPresetsFile();
+      await Bun.write(presetsFile, JSON.stringify(filtered, null, 2));
     },
     catch: (cause) =>
       new PresetError({


### PR DESCRIPTION
## Summary

- Adds `PRESETS_FILE_JSONC` path and `getPresetsFile()` to `paths.ts` — checks for `.jsonc` first, falls back to `.json`
- Adds a zero-dependency `parseJsonc()` state-machine parser to `presets.ts` that strips `//` and `/* */` comments while respecting string literals
- All preset ops (`load`, `save`, `delete`) now use `getPresetsFile()` so they transparently read/write whichever file exists

## Test plan

- [ ] Default behavior unchanged — `.json` file still used when no `.jsonc` exists
- [ ] Rename existing preset file to `.jsonc`, add comments, verify load/save/delete work correctly
- [ ] Block comments and inline comments both stripped correctly
- [ ] Comments inside string values are preserved (not stripped)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for `.jsonc` preset files with comments. The app prefers `.jsonc` when present, falls back to `.json`, and strips comments safely; saves always write plain JSON (comments are removed).

- **New Features**
  - Added `PRESETS_FILE_JSONC` and `getPresetsFile()`; all preset ops use it to prefer `.jsonc`.
  - Implemented `parseJsonc()` to strip `//` and `/* */` comments while preserving strings.

- **Dependencies**
  - Added Changeset for a minor release of `discord-search`.

<sup>Written for commit 610afc772b0636600a03c809340017e16c80f892. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `.jsonc` preset file support with comment stripping
> - Adds a `.discord-search-presets.jsonc` file path alongside the existing `.json` path, with `getPresetsFile` in [paths.ts](https://github.com/mynameistito/discord-search/pull/22/files#diff-ee5c055de3e53b22e883d37e2b0ef701779dfbd11691ca5a6504df271b53e008) preferring `.jsonc` when it exists.
> - Introduces `parseJsonc` in [presets.ts](https://github.com/mynameistito/discord-search/pull/22/files#diff-549f31156567e37e5290f0065577ecbc6500393c6986ff4a287e0bcd15be17fb) that strips `//` and `/* */` comments before calling `JSON.parse`, enabling comments in preset files.
> - Updates `loadPresets`, `savePreset`, and `deletePreset` to resolve the active file via `getPresetsFile`, so all read/write operations target `.jsonc` when present.
> - Behavioral Change: existing `.json` preset files continue to work unchanged; `.jsonc` takes precedence only when the file exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 610afc7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->