### PR TITLE
chore: update workflow action SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,14 +28,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@21eb7f7842f33eafc83782b56fff2a2c43e9696f # v4.36.1
+        uses: github/codeql-action/init@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
         with:
           languages: javascript-typescript
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@21eb7f7842f33eafc83782b56fff2a2c43e9696f # v4.36.1
+        uses: github/codeql-action/autobuild@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@21eb7f7842f33eafc83782b56fff2a2c43e9696f # v4.36.1
+        uses: github/codeql-action/analyze@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Request CODEOWNER as reviewer if none assigned
         if: ${{ toJson(github.event.pull_request.requested_reviewers) == '[]' && toJson(github.event.pull_request.requested_teams) == '[]' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
           RAW_OWNER: ${{ steps.owner.outputs.raw_owner }}
         with:


### PR DESCRIPTION
## Summary
- update CodeQL action pins to v4.36.2 SHAs
- update github-script pin to v9.0.0 SHA
- leave already-current workflow pins unchanged

## Testing
- git diff --check -- .github/workflows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated pinned SHAs in GitHub workflows to current versions to improve security and reproducibility. Other workflow pins remain unchanged.

- **Dependencies**
  - `github/codeql-action/init`, `github/codeql-action/autobuild`, `github/codeql-action/analyze`: v4.36.1 → v4.36.2
  - `actions/github-script`: v8.0.0 → v9.0.0

<sup>Written for commit 46479f2a650c8546cb658fe3156ff665acbc5597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/discord-search/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update GitHub Actions workflow SHAs for CodeQL and PR triage
> Bumps pinned SHAs for two workflow actions: `github/codeql-action` moves from v4.36.1 to v4.36.2 (init, autobuild, and analyze steps), and `actions/github-script` moves from v8.0.0 to v9.0.0 in the PR triage workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46479f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->