### PR TITLE
ci: harden release workflow

### DIFF
--- a/.changeset/quiet-squids-protect.md
+++ b/.changeset/quiet-squids-protect.md
@@ -1,0 +1,5 @@
+---
+"discord-search": patch
+---
+
+Harden and refresh CI/CD workflows with updated pinned action SHAs and protected npm publishing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -61,7 +61,7 @@ jobs:
         run: bun run build
 
       - name: Pack (dry-run)
-        run: npm pack --dry-run
+        run: bun pm pack --dry-run --ignore-scripts
 
   test-bun:
     name: Test with Bun
@@ -73,7 +73,7 @@ jobs:
     continue-on-error: ${{ matrix.bun-version == 'canary' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,16 +26,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@21eb7f7842f33eafc83782b56fff2a2c43e9696f # v4.36.1
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: javascript-typescript
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@21eb7f7842f33eafc83782b56fff2a2c43e9696f # v4.36.1
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@21eb7f7842f33eafc83782b56fff2a2c43e9696f # v4.36.1
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Parse CODEOWNERS for default owner
         id: owner
         run: |
@@ -29,7 +29,7 @@ jobs:
 
       - name: Request CODEOWNER as reviewer if none assigned
         if: ${{ toJson(github.event.pull_request.requested_reviewers) == '[]' && toJson(github.event.pull_request.requested_teams) == '[]' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RAW_OWNER: ${{ steps.owner.outputs.raw_owner }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,11 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
+    if: github.repository == 'mynameistito/discord-search' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: npm-publish
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -32,7 +34,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: bun run release
           version: bun run version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ Use short, imperative commit messages (e.g. `fix: handle missing config file`). 
 CI runs on every push and PR to `main`:
 
 1. **check** — typecheck + lint
-2. **build** — build verification + `npm pack --dry-run`
+2. **build** — build verification + `bun pm pack --dry-run --ignore-scripts`
 3. **test-bun** — `bun test` on Bun latest and canary (canary failures are non-blocking)
 
 All jobs must pass for a PR to be mergeable.


### PR DESCRIPTION
## Summary
- refresh GitHub Actions SHA pins to the latest release SHAs
- replace the CI pack check with Bun's pack dry-run command
- restrict the release job to the canonical repo's main branch
- require the npm publish path to pass through an npm-publish GitHub Environment
- add a patch changeset for the CI/CD hardening

## Verification
- bun run typecheck
- bun run check
- bun run build
- bun pm pack --dry-run --ignore-scripts
- bun test

## Notes
- Configure the npm-publish environment in GitHub with required reviewers to make the environment gate effective.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened CI/CD by updating pinned GitHub Action SHAs, gating releases, and switching to Bun’s pack dry-run. This reduces supply-chain risk and prevents accidental publishes from forks.

- **Refactors**
  - Use `bun pm pack --dry-run --ignore-scripts` for artifact checks in CI and docs.
  - Restrict release to the canonical repo’s `main` and require the `npm-publish` environment.
  - Refresh pinned SHAs: `actions/checkout`, `github/codeql-action` to v4.36.2, `actions/github-script` to v9.0.0, and `changesets/action`.
  - Add a patch changeset for the CI/CD hardening.

<sup>Written for commit 402088c37aa8843210bd6646fc4ce526757c6bb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/discord-search/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden release workflow with repository/branch guards and updated action SHAs
> - Adds job-level conditions to [release.yml](.github/workflows/release.yml) so the release job only runs on `mynameistito/discord-search` repo's `main` branch, and gates publishing behind an `npm-publish` environment.
> - Updates pinned SHAs for `actions/checkout` across all workflows and bumps `github/codeql-action` to v4.36.2 and `actions/github-script` to v9.0.0.
> - Switches the build dry-run pack command from `npm pack --dry-run` to `bun pm pack --dry-run --ignore-scripts` in [ci.yml](.github/workflows/ci.yml) and [CONTRIBUTING.md](CONTRIBUTING.md).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 402088c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->